### PR TITLE
Add pre- and post-processing to CanProcess

### DIFF
--- a/cycle_demo_client.py
+++ b/cycle_demo_client.py
@@ -47,7 +47,7 @@ class SimDriver(CanProcess, Driver):
             'poll_timer': 0.0
         }
 
-    def process(self, dt):
+    def doProcess(self, dt):
         # Updates bound parameters as needed
         for pv, binding in self._bindings.iteritems():
             binding['poll_timer'] += dt

--- a/cycle_demo_sim.py
+++ b/cycle_demo_sim.py
@@ -33,7 +33,7 @@ class SimpleChopper(CanProcessComposite, object):
             ]
         })
 
-        self.__iadd__(self._csm)
+        self.addProcessor(self._csm)
 
         self._init_vars()
 

--- a/simulation/statemachine.py
+++ b/simulation/statemachine.py
@@ -90,7 +90,7 @@ class StateMachine(CanProcess, object):
 
             # TODO: Allow user to override handler prefix settings?
 
-    def process(self, dt):
+    def doProcess(self, dt):
         """
         Process a cycle of this state machine.
 

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -4,36 +4,80 @@ import unittest
 from simulation import CanProcess, CanProcessComposite
 
 
-class TestCanProcessComposite(unittest.TestCase):
-    def test_process_calls_compositeProcess_if_present(self):
-        composite = CanProcessComposite()
+class TestCanProcess(unittest.TestCase):
+    def test_process_calls_doProcess(self):
+        processor = CanProcess()
 
-        with patch.object(composite, 'compositeProcess', create=True) as compositeProcessMock:
-            composite.process(3.0)
+        with patch.object(processor, 'doProcess', create=True) as doProcessMock:
+            processor.process(1.0)
 
-        compositeProcessMock.assert_called_once_with(3.0)
+        doProcessMock.assert_called_once_with(1.0)
 
-    def test_iadd_appends_if_is_CanProcess(self):
-        composite = CanProcessComposite()
+    def test_process_calls_doBeforeProcess_only_if_doProcess_is_present(self):
+        processor = CanProcess()
 
-        with patch.object(composite, '_appendSimulation') as appendSimulationMock:
-            composite += CanProcess()
+        with patch.object(processor, 'doBeforeProcess', create=True) as doBeforeProcessMock:
+            processor.process(1.0)
 
-        appendSimulationMock.assert_called_once()
+            doBeforeProcessMock.assert_not_called()
 
-    def test_iadd_does_not_append_if_not_CanProcess(self):
-        composite = CanProcessComposite()
+            with patch.object(processor, 'doProcess', create=True):
+                processor.process(2.0)
 
-        with patch.object(composite, '_appendSimulation') as appendSimulationMock:
-            composite += None
+            doBeforeProcessMock.assert_called_once_with(2.0)
 
-        appendSimulationMock.assert_not_called()
+    def test_process_calls_doAfterProcess_only_if_doProcess_is_present(self):
+        processor = CanProcess()
+
+        with patch.object(processor, 'doAfterProcess', create=True) as doAfterProcess:
+            processor.process(1.0)
+
+            doAfterProcess.assert_not_called()
+
+            with patch.object(processor, 'doProcess', create=True):
+                processor.process(2.0)
+
+            doAfterProcess.assert_called_once_with(2.0)
 
     @patch.object(CanProcess, 'process')
-    def test_init_from_iterable(self, mockProcessMethod):
-        simulations = (CanProcess(), CanProcess(),)
+    def test_call_invokes_process(self, processMock):
+        processor = CanProcess()
 
-        composite = CanProcessComposite(simulations)
-        composite.process(4.0)
+        processor(45.0)
 
-        mockProcessMethod.assert_has_calls([call(4.0), call(4.0)])
+        processMock.assert_called_once_with(45.0)
+
+
+class TestCanProcessComposite(unittest.TestCase):
+    def test_process_calls_doBeforeProcess_if_present(self):
+        composite = CanProcessComposite()
+
+        with patch.object(composite, 'doBeforeProcess', create=True) as doBeforeProcessMock:
+            composite.process(3.0)
+
+        doBeforeProcessMock.assert_called_once_with(3.0)
+
+    def test_addProcessor_if_argument_CanProcess(self):
+        composite = CanProcessComposite()
+
+        with patch.object(composite, '_appendProcessor') as appendProcessorMock:
+            composite.addProcessor(CanProcess())
+
+        appendProcessorMock.assert_called_once()
+
+    def test_addProcessor_if_argument_not_CanProcess(self):
+        composite = CanProcessComposite()
+
+        with patch.object(composite, '_appendProcessor') as appendProcessorMock:
+            composite.addProcessor(None)
+
+        appendProcessorMock.assert_not_called()
+
+    def test_init_from_iterable(self):
+        with patch.object(CanProcess, 'doProcess', create=True) as mockProcessMethod:
+            simulations = (CanProcess(), CanProcess(),)
+
+            composite = CanProcessComposite(simulations)
+            composite(4.0)
+
+            mockProcessMethod.assert_has_calls([call(4.0), call(4.0)])


### PR DESCRIPTION
The changes address issue #18.
- `CanProcess` now supports pre- and post-processing, which is probably irrelevant in the usual case, but for the `Composite` it opens up some possibilities.
- `CanProcess` has a `__call__`-method now which maps to `process`, this way client code may become shorter in a few cases or at least nicer to look at.
- The `__iadd__`-operator of `CanProcessComposite` has been dropped in favour of an `addProcessor`-method which makes it a bit more explicit when using `self`.

Unit tests have been updated, so has the "client code" (mostly renaming from `process` to `doProcess`).
