### PR TITLE
Renamed Context.setInitialState to Context.initialize

### DIFF
--- a/simulation/chopper/defaults.py
+++ b/simulation/chopper/defaults.py
@@ -22,7 +22,7 @@ from simulation.core import State
 
 class DefaultInitState(State):
     def on_entry(self, dt):
-        self._context.setInitialState()
+        self._context.initialize()
 
 
 class DefaultParkingState(State):

--- a/simulation/chopper/device.py
+++ b/simulation/chopper/device.py
@@ -71,7 +71,7 @@ class SimulatedBearings(CanProcess, MagneticBearings):
 
 
 class ChopperContext(Context):
-    def setInitialState(self):
+    def initialize(self):
         self.speed = 0.0
         self.target_speed = 0.0
 

--- a/simulation/core/statemachine.py
+++ b/simulation/core/statemachine.py
@@ -29,19 +29,19 @@ class Context(object):
     __is_frozen = False
 
     def __init__(self):
-        self.setInitialState()
+        self.initialize()
         self._freeze()
+
+    def initialize(self):
+        pass
+
+    def _freeze(self):
+        self.__is_frozen = True
 
     def __setattr__(self, key, value):
         if self.__is_frozen and not hasattr(self, key):
             raise StateMachineException("Class {} does not have attribute: '{}'".format(self.__class__.__name__, key))
         object.__setattr__(self, key, value)
-
-    def setInitialState(self):
-        pass
-
-    def _freeze(self):
-        self.__is_frozen = True
 
 
 class HasContext(object):


### PR DESCRIPTION
Just a tiny thing that was bugging me. Seems like a more natural name / clearer that this will be called on instantiation (and still makes sense for `my_context.initialize()`).
