### PR TITLE
SimulatedChopper checks overrides for states and transitions

### DIFF
--- a/simulation/chopper/device.py
+++ b/simulation/chopper/device.py
@@ -19,6 +19,7 @@
 
 from collections import OrderedDict
 from simulation.core import StateMachine, CanProcessComposite, CanProcess, Context
+from simulation.core.utils import dict_strict_update
 from bearings import MagneticBearings
 from defaults import *
 
@@ -115,7 +116,7 @@ class SimulatedChopper(CanProcessComposite, object):
         }
 
         if override_states is not None:
-            state_handlers.update(override_states)
+            dict_strict_update(state_handlers, override_states)
 
         transition_handlers = OrderedDict([
             (('init', 'bearings'), lambda: self._context.interlocked),
@@ -154,7 +155,7 @@ class SimulatedChopper(CanProcessComposite, object):
         ])
 
         if override_transitions is not None:
-            transition_handlers.update(override_transitions)
+            dict_strict_update(transition_handlers, override_transitions)
 
         self._csm = StateMachine({
             'initial': 'init',

--- a/simulation/core/utils.py
+++ b/simulation/core/utils.py
@@ -28,11 +28,10 @@ def dict_strict_update(base_dict, update_dict):
     :param base_dict: The dict that is to be updated. This dict is modified.
     :param update_dict: The dict containing the new values.
     """
-    if update_dict is not None:
-        additional_keys = update_dict.viewkeys() - base_dict.viewkeys()
-        if len(additional_keys) > 0:
-            raise RuntimeError(
-                'The update dictionary contains keys that are not part of the base dictionary: {}'.format(
-                    str(additional_keys)))
+    additional_keys = update_dict.viewkeys() - base_dict.viewkeys()
+    if len(additional_keys) > 0:
+        raise RuntimeError(
+            'The update dictionary contains keys that are not part of the base dictionary: {}'.format(
+                str(additional_keys)))
 
-        base_dict.update(update_dict)
+    base_dict.update(update_dict)

--- a/simulation/core/utils.py
+++ b/simulation/core/utils.py
@@ -1,0 +1,38 @@
+#  -*- coding: utf-8 -*-
+# *********************************************************************
+# plankton - a library for creating hardware device simulators
+# Copyright (C) 2016 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+def dict_strict_update(base_dict, update_dict):
+    """
+    This function updates base_dict with update_dict if and only if update_dict does not contain
+    keys that are not already in base_dict. It is essentially a more strict interpretation of the
+    term "updating" the dict.
+
+    If update_dict contains keys that are not in base_dict, a RuntimeError is raised.
+
+    :param base_dict: The dict that is to be updated. This dict is modified.
+    :param update_dict: The dict containing the new values.
+    """
+    if update_dict is not None:
+        additional_keys = update_dict.viewkeys() - base_dict.viewkeys()
+        if len(additional_keys) > 0:
+            raise RuntimeError(
+                'The update dictionary contains keys that are not part of the base dictionary: {}'.format(
+                    str(additional_keys)))
+
+        base_dict.update(update_dict)

--- a/test/test_SimulatedChopper.py
+++ b/test/test_SimulatedChopper.py
@@ -1,0 +1,40 @@
+#  -*- coding: utf-8 -*-
+# *********************************************************************
+# plankton - a library for creating hardware device simulators
+# Copyright (C) 2016 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+import unittest
+from simulation.chopper import SimulatedChopper, DefaultIdleState
+
+
+class TestSimulatedChopper(unittest.TestCase):
+    def test_invalid_state_override_fails(self):
+        self.assertRaises(RuntimeError, SimulatedChopper, override_states={'invalid': DefaultIdleState()})
+
+    def test_valid_state_override_does_not_fail(self):
+        chopper = SimulatedChopper(override_states={'idle': DefaultIdleState()})
+
+        self.assertIsInstance(chopper, SimulatedChopper)
+
+    def test_invalid_transition_override_fails(self):
+        self.assertRaises(RuntimeError, SimulatedChopper,
+                          override_transitions={('idle', 'phase_locking'): lambda: True})
+
+    def test_valid_transition_override_does_not_fail(self):
+        chopper = SimulatedChopper(override_transitions={('idle', 'stopping'): lambda: True})
+
+        self.assertIsInstance(chopper, SimulatedChopper)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,45 @@
+#  -*- coding: utf-8 -*-
+# *********************************************************************
+# plankton - a library for creating hardware device simulators
+# Copyright (C) 2016 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+import unittest
+from simulation.core.utils import dict_strict_update
+
+
+class TestDictStrictUpdate(unittest.TestCase):
+    def test_update_all(self):
+        base_dict = {1: 2, 2: 45, 4: 4}
+        update_dict = {1: 3, 2: 43, 4: 3}
+
+        dict_strict_update(base_dict, update_dict)
+
+        self.assertEqual(base_dict, update_dict)
+
+    def test_update_subset(self):
+        base_dict = {1: 2, 2: 45, 4: 4}
+        update_dict = {1: 3, 2: 43}
+
+        dict_strict_update(base_dict, update_dict)
+
+        self.assertEqual(base_dict, {1: 3, 2: 43, 4: 4})
+
+    def test_update_superset_exception(self):
+        base_dict = {1: 2, 2: 45, 4: 4}
+        update_dict = {51: 3, 2: 43}
+
+        self.assertRaises(RuntimeError, dict_strict_update, base_dict, update_dict)


### PR DESCRIPTION
This closes #22.

Added a more strict update function for dictionaries that raises an exception when the update dictionary contains keys that are not in the base dictionary. Not entirely sure `utils` is the best name, maybe you have another suggestion?

There are also a few tests, but the one for `SimpleChopper` only has test cases for this specific issue.
