### PR TITLE
Additional renaming as part of restructure PR

### DIFF
--- a/setups/__init__.py
+++ b/setups/__init__.py
@@ -22,25 +22,25 @@ import importlib
 from core import CanProcess
 
 
-def import_device(device_type, scenario):
+def import_device(device_type, setup):
     """
     This function is a helper that imports the first object which is an instance of devices.core.CanProcess
     from the setups package:
 
-        from setups.device_type.scenario import can_process_object.
+        from setups.device_type.setup import can_process_object.
 
-    The object is returned by the function, so to import the default scenario for chopper:
+    The object is returned by the function, so to import the default setup for chopper:
 
         chopper = import_device('chopper', 'default')
 
-    :param device_type: Sub-package from which to import the scenario.
-    :param scenario: Scenario module from which to import the device object.
-    :return: Device object as specified by device_type and scenario
+    :param device_type: Sub-package from which to import the setup.
+    :param setup: Setup module from which to import the device object.
+    :return: Device object as specified by device_type and setup
     """
-    module_name = '.{}'.format(scenario)
-    scenario_package = 'setups.{}'.format(device_type)
+    module_name = '.{}'.format(setup)
+    setup_package = 'setups.{}'.format(device_type)
 
-    module = importlib.import_module(module_name, scenario_package)
+    module = importlib.import_module(module_name, setup_package)
 
     for module_member in dir(module):
         module_object = getattr(module, module_member)
@@ -49,7 +49,7 @@ def import_device(device_type, scenario):
             return module_object
 
     raise RuntimeError(
-        'Did not find anything that implements CanProcess in module \'{}\'.'.format(scenario_package + module_name))
+        'Did not find anything that implements CanProcess in module \'{}\'.'.format(setup_package + module_name))
 
 
 def import_bindings(device_type, bindings_type):

--- a/simulation.py
+++ b/simulation.py
@@ -45,7 +45,7 @@ class StoreNameValuePairs(argparse.Action):
 parser = argparse.ArgumentParser(
     description='Run a simulated device and expose it via a specified communication protocol.')
 parser.add_argument('-d', '--device', help='Name of the device to simulate.', default='chopper', choices=['chopper'])
-parser.add_argument('-s', '--setup', help='Name of the scenario to run.', default='default')
+parser.add_argument('-s', '--setup', help='Name of the setup to load.', default='default')
 parser.add_argument('-b', '--bindings', help='Bindings to import from setups.device.bindings. '
                                              'If not specified, this defaults to the value of --protocol.')
 parser.add_argument('-p', '--protocol', help='Communication protocol to expose devices.', default='epics',
@@ -60,7 +60,7 @@ arguments = parser.parse_args()
 CommunicationAdapter = import_adapter(arguments.protocol, arguments.adapter)
 
 bindings = import_bindings(arguments.device, arguments.protocol if arguments.bindings is None else arguments.bindings)
-device = import_device(arguments.device, arguments.scenario)
+device = import_device(arguments.device, arguments.setup)
 
 adapter = CommunicationAdapter()
 adapter.run(device, bindings, **arguments.parameters)

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -94,9 +94,9 @@ class TestCanProcessComposite(unittest.TestCase):
 
     def test_init_from_iterable(self):
         with patch.object(CanProcess, 'doProcess', create=True) as mockProcessMethod:
-            simulations = (CanProcess(), CanProcess(),)
+            devices = (CanProcess(), CanProcess(),)
 
-            composite = CanProcessComposite(simulations)
+            composite = CanProcessComposite(devices)
             composite(4.0)
 
             mockProcessMethod.assert_has_calls([call(4.0), call(4.0)])


### PR DESCRIPTION
Picks up on some renaming that was missed in #48 to restructure plankton module layout and naming as part of #41.

The only functional change is in `simulation.py`, line 63. The others are purely cosmetic or for consistency.
