### PR TITLE
Use better init system for Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM dmscid/epics-pcaspy:latest
 
-ADD . /plankton
+COPY . /plankton
 
 RUN pip install -r plankton/requirements.txt && \
     pip install -r plankton/requirements-dev.txt
 
-ENTRYPOINT ["sh", "-lc", "python $@", "python", "/plankton/simulation.py"]
+ENTRYPOINT ["/init.sh", "python", "/plankton/simulation.py"]
 


### PR DESCRIPTION
Closes #50.

This introduces an `/init.sh` script combined with [tini](https://github.com/krallin/tini) (`/init` in the image) as a miniature init/supervisor system. This replaces the previous approach of running everything through a login shell to get `/etc/profile` automatically sourced.

The script has the following usage:
`$ /init.sh [command [arguments]]`

This will do the following:
- `/etc/profile` is `source`d to set up the environment (which in turn `source`s `/etc/profile.d/*.sh`)
- `[command]` is run with `[arguments]`, via tini (`/init -s -g`)
- If no command was provided, `/bin/sh` is used as a default
- Assuming the script is run as the ENTRYPOINT or CMD, tini will have PID 1 so that it will receive any signals the container receives from the host
- tini will reap child processes so they don't turn into zombies and forward any signals it receives to all child processes

Nothing changes for normal `dmscid/plankton` usage, e.g.:
`$ docker run -it dmscid/plankton --parameters pv_prefix=SIM:`

The init process can be avoided using `--entrypoint sh`:
`$ docker run -it --entrypoint sh dmscid/plankton`

When running a container like that, you can switch to "init-mode" by sourcing `init.sh`:

``` sh
$ docker run -it --rm --entrypoint sh dmscid/plankton
ac28333e09e1:/# ps aux
PID   USER     TIME   COMMAND
    1 root       0:00 sh
   11 root       0:00 ps aux
ac28333e09e1:/# . /init.sh 
ac28333e09e1:/# ps aux
PID   USER     TIME   COMMAND
    1 root       0:00 /init -s -g /bin/sh
   15 root       0:00 /bin/sh
   19 root       0:00 ps aux
ac28333e09e1:/# exit
$
```

Notice that the `sh` process at PID 1 was replaced by `/init` and the first `exit` shuts down the container (even though a new shell was started).

Most of this is in https://github.com/DMSC-Instrument-Data/plankton-misc/commit/1141eeb0645e2e77e1f178b5479eaf737e0e6ae7, the commit associated with this PR only updates the `dmscid/plankton` image to use the new script.
