### PR TITLE
Changed command names to leave init state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following series of `caput`-commands, executed from a different terminal, wi
 speed and phase:
 
 ```
-$ caput SIM:COMMAND INTERLOCK
+$ caput SIM:COMMAND INIT
 $ caput SIM:SPEED:SP 100.0
 $ caput SIM:PHASE:SP 23.0
 $ caput SIM:COMMAND START
@@ -87,7 +87,7 @@ The states marked with a * are not implemented yet and are not present in choppe
 - LEVITATE*: Levitate disc if it's not levitated
 - DELEVITATE*: Delevitate disc if possible
 
-The commands marked with a * are not implemented yet. There are however two additional commands, INTERLOCK and RELEASE. INTERLOCK takes the chopper from the initial `init` state to the `stopped` state, RELEASE does the opposite. This behavior will likely change soon.
+The commands marked with a * are not implemented yet. There are however two additional commands, INIT and DEINIT. INIT takes the chopper from the initial `init` state to the `stopped` state, DEINIT does the opposite.
 
 ## Additional tools
 

--- a/devices/chopper/device.py
+++ b/devices/chopper/device.py
@@ -90,7 +90,7 @@ class ChopperContext(Context):
         self.idle_commanded = False
         self.phase_commanded = False
         self.shutdown_commanded = False
-        self.interlocked = False
+        self.initialized = False
 
 
 class SimulatedChopper(CanProcessComposite, object):
@@ -121,7 +121,7 @@ class SimulatedChopper(CanProcessComposite, object):
             dict_strict_update(state_handlers, override_states)
 
         transition_handlers = OrderedDict([
-            (('init', 'bearings'), lambda: self._context.interlocked),
+            (('init', 'bearings'), lambda: self._context.initialized),
             (('bearings', 'stopped'), lambda: self._bearings.ready),
             (('bearings', 'init'), lambda: self._bearings.idle),
 
@@ -172,14 +172,14 @@ class SimulatedChopper(CanProcessComposite, object):
         return self._csm.state
 
     @property
-    def interlocked(self):
-        return self._context.interlocked
+    def initialized(self):
+        return self._context.initialized
 
-    def interlock(self):
-        self._context.interlocked = True
+    def initialize(self):
+        self._context.initialized = True
         self._bearings.engage()
 
-    def release(self):
+    def deinitialize(self):
         self._context.shutdown_commanded = True
         self._bearings.disengage()
 

--- a/setups/chopper/bindings.py
+++ b/setups/chopper/bindings.py
@@ -37,8 +37,8 @@ epics = {
                     'PHASE': 'lockPhase',
                     'COAST': 'unlock',
                     'PARK': 'park',
-                    'INTERLOCK': 'interlock',
-                    'RELEASE': 'release'
+                    'INIT': 'initialize',
+                    'DEINIT': 'deinitialize'
                 },
                 'buffer': 'LAST_COMMAND'},
 


### PR DESCRIPTION
Closes #58.

The command to leave the init state is now called `INIT`, the command to leave the stopped-state back to init is `DEINIT`.

All references to "interlock" have been removed, the readme has been updated.
