### PR TITLE
Remove hardcoded choices from startup

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -80,6 +80,7 @@ def is_module(module, paths):
         imp.find_module(module, paths)
         return True
     except (ImportError, TypeError) as error:
+        print error.message
         return False
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -23,18 +23,19 @@ import os.path as osp
 from os import listdir
 
 
-def get_available_submodules(package):
+def get_available_submodules(package, search_path=None):
     """
     This function returns a list of available submodules in a package.
 
     :param package: Name of the package.
+    :param search_path: List of paths to search for package or None. Passed to imp.find_module
     :return: Available submodules in package.
     """
-    file_name, path, descriptor = imp.find_module(package)
+    file_name, path, descriptor = imp.find_module(package, search_path)
 
     submodule_candidates = [extract_module_name(osp.join(path, entry)) for entry in listdir(path)]
 
-    return [submodule for submodule in submodule_candidates if is_submodule(submodule, package)]
+    return [submodule for submodule in submodule_candidates if is_module(submodule, [path])]
 
 
 def extract_module_name(absolute_path):
@@ -67,18 +68,18 @@ def extract_module_name(absolute_path):
     return None
 
 
-def is_submodule(module, package):
+def is_module(module, paths):
     """
     Small helper function that returns True if module is a sub-module in package.
 
     :param module: Name of the sub-module to check.
-    :param package: Name of the package where the sub-module resides.
+    :param path: List of paths where the module is located.
     :return: True if module is a sub-module of package.
     """
     try:
-        importlib.import_module('{}.{}'.format(package, module))
+        imp.find_module(module, paths)
         return True
-    except ImportError:
+    except (ImportError, TypeError) as error:
         return False
 
 

--- a/simulation.py
+++ b/simulation.py
@@ -18,6 +18,7 @@
 # *********************************************************************
 
 import argparse
+from core.utils import get_available_submodules
 from adapters import import_adapter
 from setups import import_device, import_bindings
 
@@ -44,16 +45,18 @@ class StoreNameValuePairs(argparse.Action):
 
 parser = argparse.ArgumentParser(
     description='Run a simulated device and expose it via a specified communication protocol.')
-parser.add_argument('-d', '--device', help='Name of the device to simulate.', default='chopper', choices=['chopper'])
+parser.add_argument('-d', '--device', help='Name of the device to simulate.', default='chopper',
+                    choices=get_available_submodules('setups'))
 parser.add_argument('-s', '--setup', help='Name of the setup to load.', default='default')
 parser.add_argument('-b', '--bindings', help='Bindings to import from setups.device.bindings. '
                                              'If not specified, this defaults to the value of --protocol.')
 parser.add_argument('-p', '--protocol', help='Communication protocol to expose devices.', default='epics',
-                    choices=['epics'])
+                    choices=get_available_submodules('adapters'))
 parser.add_argument('-a', '--adapter',
                     help='Name of adapter class. If not specified, the loader will choose '
                          'the first adapter it discovers.')
-parser.add_argument('--parameters', help='Additional parameters for the protocol.', action=StoreNameValuePairs)
+parser.add_argument('--parameters', help='Additional parameters for the protocol, key=value pairs separated by comma.',
+                    action=StoreNameValuePairs)
 
 arguments = parser.parse_args()
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -151,4 +151,5 @@ from core.utils import get_available_submodules
 
 class TestGetAvailableSubModules(TestWithPackageStructure):
     def test_correct_modules_are_returned(self):
-        self.assertEqual(get_available_submodules(self._tmp_package_name, [self._tmp_dir]), self._expected_modules)
+        self.assertEqual(sorted(get_available_submodules(self._tmp_package_name, [self._tmp_dir])),
+                         sorted(self._expected_modules))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -74,6 +74,9 @@ def generate_fake_package_structure():
     for abs_dir_name in dirs.values():
         os.mkdir(abs_dir_name)
 
+    with open(os.path.join(_tmp_package, '__init__.py'), 'w'):
+        pass
+
     with open(os.path.join(_tmp_package, 'some_dir', '__init__.py'), 'w'):
         pass
 
@@ -81,11 +84,11 @@ def generate_fake_package_structure():
 
 
 class TestExtractModuleName(unittest.TestCase):
-    def setUp(self):
-        self._tmp_package, tmp_dir, self._files, self._dirs, expected = generate_fake_package_structure()
+    def setUpClass(cls):
+        cls._tmp_package, tmp_dir, cls._files, cls._dirs, expected = generate_fake_package_structure()
 
-    def tearDown(self):
-        shutil.rmtree(self._tmp_package)
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmp_package)
 
     def test_directory_basename_is_returned(self):
         self.assertEqual(extract_module_name(self._dirs['valid']), 'some_dir')
@@ -101,3 +104,27 @@ class TestExtractModuleName(unittest.TestCase):
 
     def test_file_basename_without_extension(self):
         self.assertEqual(extract_module_name(self._files['valid']), 'some_file')
+
+
+from core.utils import is_module
+
+
+class TestIsModule(unittest.TestCase):
+    def setUpClass(cls):
+        cls._tmp_package, tmp_dir, cls._files, cls._dirs, _expected = generate_fake_package_structure()
+
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmp_package)
+        pass
+
+    def test_valid_directory(self):
+        self.assertTrue(is_module(self._dirs['valid'], [self._tmp_package]))
+
+    def test_invalid_directory(self):
+        self.assertFalse(is_module(self._dirs['invalid'], [self._tmp_package]))
+
+    def test_invalid_file_name(self):
+        self.assertFalse(is_module(self._files['invalid_name'], [self._tmp_package]))
+
+    def test_invalid_file_ext(self):
+        self.assertFalse(is_module(self._files['invalid_ext'], [self._tmp_package]))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -44,3 +44,60 @@ class TestDictStrictUpdate(unittest.TestCase):
         update_dict = {51: 3, 2: 43}
 
         self.assertRaises(RuntimeError, dict_strict_update, base_dict, update_dict)
+
+
+from core.utils import extract_module_name
+import os, shutil
+import tempfile
+
+
+def generate_fake_package_structure():
+    _tmp_package = tempfile.mkdtemp()
+    _tmp_dir = tempfile.gettempdir()
+
+    files = {k: os.path.join(_tmp_package, v) for k, v in dict(
+        valid='some_file.py',
+        invalid_ext='some_other_file.pyc',
+        invalid_name='_some_invalid_file.py',
+    ).iteritems()}
+
+    for abs_file_name in files.values():
+        with open(abs_file_name, mode='w'):
+            pass
+
+    dirs = {k: os.path.join(_tmp_package, v) for k, v in dict(
+        valid='some_dir',
+        empty='empty_dir',
+        invalid='_invalid',
+    ).iteritems()}
+
+    for abs_dir_name in dirs.values():
+        os.mkdir(abs_dir_name)
+
+    with open(os.path.join(_tmp_package, 'some_dir', '__init__.py'), 'w'):
+        pass
+
+    return _tmp_package, _tmp_dir, files, dirs, ['some_file', 'some_dir']
+
+
+class TestExtractModuleName(unittest.TestCase):
+    def setUp(self):
+        self._tmp_package, tmp_dir, self._files, self._dirs, expected = generate_fake_package_structure()
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_package)
+
+    def test_directory_basename_is_returned(self):
+        self.assertEqual(extract_module_name(self._dirs['valid']), 'some_dir')
+
+    def test_directory_invalid_name(self):
+        self.assertEqual(extract_module_name(self._dirs['invalid']), None)
+
+    def test_file_invalid_name(self):
+        self.assertEqual(extract_module_name(self._files['invalid_name']), None)
+
+    def test_file_invalid_extension(self):
+        self.assertEqual(extract_module_name(self._files['invalid_ext']), None)
+
+    def test_file_basename_without_extension(self):
+        self.assertEqual(extract_module_name(self._files['valid']), 'some_file')


### PR DESCRIPTION
Closes #54.

A few functions were added to `core.util` which help getting all submodules in a package. It may not be 100% general, but I think for our cases so far it works. Unit tests have been added, they use a fake package structure that is set up in the system's temporary directory (and removed during tear down).

For manual testing I suggest running `python simulation.py -h` to see that all adapters and setups are still there.
