### PR TITLE
Added automatic parking switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ At a minimum, the following PVs will be exposed:
 | Phs  |  Phase setpoint. | Degree | Read/Write |
 | ParkAng-RB  |  Current position of chopper disc if in parked state. | Degree | Read |
 | ParkAng  |  Position to which the disc should rotate in parked state. | Degree | Read/Write |
+| AutoPark | Enum `false`/`true` (or 0/1). If enabled, the chopper will move to the parking state when the stop state is reached. | - | Read/Write |
 | State  |  Enum for chopper state. | - | Read |
 | TDCE*  |  Vector of TDC (top dead center) events in last accelerator pulse. | to be determined | Read |
 | Dir-RB*  |  Enum for rotation direction (clockwise, counter clockwise). | - | Read |

--- a/devices/chopper/defaults.py
+++ b/devices/chopper/defaults.py
@@ -66,7 +66,9 @@ class DefaultStoppingState(State):
 
 
 class DefaultStoppedState(State):
-    pass
+    def on_entry(self, dt):
+        if self._context.automatic_park_enabled:
+            self._context.park_commanded = True
 
 
 class DefaultIdleState(State):

--- a/devices/chopper/device.py
+++ b/devices/chopper/device.py
@@ -84,6 +84,7 @@ class ChopperContext(Context):
         self.parking_position = 0.0
         self.target_parking_position = 0.0
 
+        self.automatic_park_enabled = False
         self.park_commanded = False
         self.stop_commanded = False
         self.start_commanded = False
@@ -189,6 +190,14 @@ class SimulatedChopper(CanProcessComposite, object):
     @property
     def parked(self):
         return self._csm.state == 'parked'
+
+    @property
+    def autoPark(self):
+        return self._context.automatic_park_enabled
+
+    @autoPark.setter
+    def autoPark(self, enable):
+        self._context.automatic_park_enabled = bool(enable)
 
     # Stopping stuff
     def stop(self):

--- a/setups/chopper/bindings.py
+++ b/setups/chopper/bindings.py
@@ -29,20 +29,23 @@ epics = {
 
     'ParkAng-RB': {'property': 'parkingPosition'},
     'ParkAng': {'property': 'targetParkingPosition'},
+    'AutoPark': {'type': 'enum',
+                 'enums': ['false', 'true'],
+                 'property': 'autoPark'},
 
     'State': {'type': 'string', 'property': 'state'},
 
     'CmdS': {'type': 'string',
-                'commands': {
-                    'start': 'start',
-                    'stop': 'stop',
-                    'set_phase': 'lockPhase',
-                    'unlock': 'unlock',
-                    'park': 'park',
-                    'init': 'initialize',
-                    'deinit': 'deinitialize'
-                },
-                'buffer': 'CmdL'},
+             'commands': {
+                 'start': 'start',
+                 'stop': 'stop',
+                 'set_phase': 'lockPhase',
+                 'unlock': 'unlock',
+                 'park': 'park',
+                 'init': 'initialize',
+                 'deinit': 'deinitialize'
+             },
+             'buffer': 'CmdL'},
 
     'CmdL': {'type': 'string'}
 }


### PR DESCRIPTION
Closes #60.

There is now a new switch in the chopper context that will automatically trigger `park_commanded` when `stopped` is entered if activated. It's exposed via a new PV that is an enum (`false`, `true`) - this makes the usual EPICS 0, 1 syntax possible as well as using `false` and `true`.
