### PR TITLE
Linkam T95 Device with TCP Stream Adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ COPY . /plankton
 RUN pip install -r plankton/requirements.txt && \
     pip install -r plankton/requirements-dev.txt
 
-ENTRYPOINT ["/init.sh", "python", "/plankton/simulation.py"]
+ENTRYPOINT ["/init.sh", "/plankton/simulation.py"]
 

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -1,0 +1,86 @@
+#  -*- coding: utf-8 -*-
+# *********************************************************************
+# plankton - a library for creating hardware device simulators
+# Copyright (C) 2016 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+import SocketServer
+import re
+
+from adapters import Adapter
+from datetime import datetime
+
+
+class StreamHandler(SocketServer.StreamRequestHandler):
+    def handle(self):
+        request = self.rfile.readline().strip()
+        reply = None
+
+        for command, funcname in self.server.bindings.iteritems():
+            if request.startswith(command):
+                func = getattr(self.server.target, funcname)
+                args = request[len(command):]
+                reply = func(args) if args else func()
+
+        """
+        if request == "STATE?":
+            reply = self.server.target.state + "\n"
+        if request == "INIT!":
+            self.server.target.initialize()
+            reply = "Initializing\n"
+        if request == "STATS?":
+            speed = self.server.target.speed
+            phase = self.server.target.phase
+            reply = "%.2f rpm @ %.2f deg\n" % (speed, phase)
+        if request.startswith("GO!"):
+            m = re.match("GO!(\d+(?:\.\d+)?)@(\d+(?:\.\d+)?)", request)
+            if m is None:
+                reply = "INVALID FORMAT!\n"
+            else:
+                self.server.target.targetSpeed = float(m.group(1))
+                self.server.target.targetPhase = float(m.group(2))
+                self.server.target.start()
+                reply = "START COMMANDED!\n"
+        """
+
+        if reply is not None:
+            self.request.sendall(str(reply))
+
+
+class StreamAdapter(Adapter):
+    def run(self, target, bindings, *args, **kwargs):
+        server = SocketServer.TCPServer(("localhost", 9999), StreamHandler)
+        server.timeout = 0.1
+        server.target = target
+        server.bindings = bindings
+
+        delta = 0.0  # Delta between cycles
+        count = 0  # Cycles per second counter
+        timer = 0.0  # Second counter
+
+        while True:
+            start = datetime.now()
+
+            server.handle_request()
+            target.process(delta)
+
+            delta = (datetime.now() - start).total_seconds()
+            count += 1
+            timer += delta
+            if timer >= 1.0:
+                print "Running at %d cycles per second (%.3f ms per cycle)" % (count, 1000.0 / count)
+                count = 0
+                timer = 0.0

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -46,7 +46,10 @@ class StreamHandler(asynchat.async_chat):
             if request.startswith(command):
                 func = getattr(self.target, funcname)
                 args = request[len(command):]
-                reply = func(args) if args else func()
+                try:
+                    reply = func(args) if args else func()
+                except Exception:
+                    pass
 
         if reply is not None:
             self.push(str(reply) + self.bindings['meta']['out_terminator'])

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -49,6 +49,8 @@ class StreamHandler(asynchat.async_chat):
                 try:
                     reply = func(args) if args else func()
                 except Exception:
+                    # We're ignoring this temporarily as per Linkam T95 spec
+                    # In the long term, we need to come up with a way for the device to decide how errors are handled.
                     pass
 
         if reply is not None:

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -72,7 +72,7 @@ class StreamServer(asyncore.dispatcher):
 
 class StreamAdapter(Adapter):
     def run(self, target, bindings, *args, **kwargs):
-        StreamServer("localhost", 9999, target, bindings)
+        StreamServer("0.0.0.0", 9999, target, bindings)
 
         delta = 0.0  # Delta between cycles
         count = 0  # Cycles per second counter

--- a/core/utils.py
+++ b/core/utils.py
@@ -34,7 +34,6 @@ def get_available_submodules(package, search_path=None):
     file_name, path, descriptor = imp.find_module(package, search_path)
 
     submodule_candidates = [extract_module_name(osp.join(path, entry)) for entry in listdir(path)]
-    submodule_candidates = filter(lambda x: x is not None, submodule_candidates)
 
     return [submodule for submodule in submodule_candidates if is_module(submodule, [path])]
 
@@ -80,8 +79,7 @@ def is_module(module, paths):
     try:
         imp.find_module(module, paths)
         return True
-    except (ImportError, TypeError) as error:
-        print error.message
+    except (ImportError, TypeError):
         return False
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -34,6 +34,7 @@ def get_available_submodules(package, search_path=None):
     file_name, path, descriptor = imp.find_module(package, search_path)
 
     submodule_candidates = [extract_module_name(osp.join(path, entry)) for entry in listdir(path)]
+    submodule_candidates = filter(lambda x: x is not None, submodule_candidates)
 
     return [submodule for submodule in submodule_candidates if is_module(submodule, [path])]
 

--- a/devices/linkam_t95/__init__.py
+++ b/devices/linkam_t95/__init__.py
@@ -17,5 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from chopper import SimulatedChopper
-from linkam_t95 import SimulatedLinkamT95
+from device import SimulatedLinkamT95
+from defaults import *
+

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -52,12 +52,13 @@ class DefaultCoolState(State):
             self._context.pump_speed = self._context.manual_target_speed
         else:
             # TODO: Figure out real correlation
-            self._context.pump_speed = int(30 * (self._context.temperature_rate / 50.0))
+            self._context.pump_speed = 30 * (self._context.temperature_rate / 50.0)
 
         if self._context.pump_speed > 30:
             self._context.pump_speed = 30
             self._context.pump_overspeed = True
         else:
+            self._context.pump_speed = int(self._context.pump_speed)
             self._context.pump_overspeed = False
 
         # TODO: Should be based on pump speed somehow

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -36,7 +36,15 @@ class DefaultStartedState(State):
 
 
 class DefaultHeatState(State):
-    pass
+    def in_state(self, dt):
+        self._context.pump_speed = int(30 * (50.0 / self._context.temperature_rate))
+        if self._context.pump_speed > 30:
+            self._context.pump_speed = 30
+            # TODO: Set error flag?
+
+        self._context.temperature += self._context.temperature_rate * (dt / 60.0)
+        if self._context.temperature > self._context.temperature_limit:
+            self._context.temperature = self._context.temperature_limit
 
 
 class DefaultHoldState(State):
@@ -44,4 +52,12 @@ class DefaultHoldState(State):
 
 
 class DefaultCoolState(State):
-    pass
+    def in_state(self, dt):
+        self._context.pump_speed = int(30 * (50.0 / self._context.temperature_rate))
+        if self._context.pump_speed > 30:
+            self._context.pump_speed = 30
+            # TODO: Set error flag?
+
+        self._context.temperature -= self._context.temperature_rate * (dt / 60.0)
+        if self._context.temperature < self._context.temperature_limit:
+            self._context.temperature = self._context.temperature_limit

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -43,8 +43,7 @@ class DefaultHeatState(State):
 
 
 class DefaultHoldState(State):
-    def on_entry(self, dt):
-        self._context.pump_speed = 0
+    pass
 
 
 class DefaultCoolState(State):
@@ -68,3 +67,4 @@ class DefaultCoolState(State):
 
     def on_exit(self, dt):
         self._context.pump_overspeed = False
+        self._context.pump_speed = 0

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -37,27 +37,38 @@ class DefaultStartedState(State):
 
 class DefaultHeatState(State):
     def in_state(self, dt):
-        self._context.pump_speed = int(30 * (50.0 / self._context.temperature_rate))
+        if self._context.pump_manual_mode:
+            self._context.pump_speed = self._context.manual_target_speed
+        else:
+            self._context.pump_speed = int(30 * (self._context.temperature_rate / 50.0))
+
         if self._context.pump_speed > 30:
             self._context.pump_speed = 30
             # TODO: Set error flag?
 
+        # TODO: Should be based on pump speed somehow
         self._context.temperature += self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature > self._context.temperature_limit:
             self._context.temperature = self._context.temperature_limit
 
 
 class DefaultHoldState(State):
-    pass
+    def on_entry(self, dt):
+        self._context.pump_speed = 0
 
 
 class DefaultCoolState(State):
     def in_state(self, dt):
-        self._context.pump_speed = int(30 * (50.0 / self._context.temperature_rate))
+        if self._context.pump_manual_mode:
+            self._context.pump_speed = self._context.manual_target_speed
+        else:
+            self._context.pump_speed = int(30 * (self._context.temperature_rate / 50.0))
+
         if self._context.pump_speed > 30:
             self._context.pump_speed = 30
             # TODO: Set error flag?
 
+        # TODO: Should be based on pump speed somehow
         self._context.temperature -= self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature < self._context.temperature_limit:
             self._context.temperature = self._context.temperature_limit

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -17,5 +17,26 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from chopper import SimulatedChopper
-from linkam_t95 import SimulatedLinkamT95
+from core import State
+
+
+class DefaultStoppedState(State):
+    def on_entry(self, dt):
+        self._context.initialize()
+
+
+class DefaultStartedState(State):
+    def on_entry(self, dt):
+        self._context.start_commanded = False
+
+
+class DefaultHeatState(State):
+    pass
+
+
+class DefaultHoldState(State):
+    pass
+
+
+class DefaultCoolState(State):
+    pass

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -37,16 +37,6 @@ class DefaultStartedState(State):
 
 class DefaultHeatState(State):
     def in_state(self, dt):
-        if self._context.pump_manual_mode:
-            self._context.pump_speed = self._context.manual_target_speed
-        else:
-            self._context.pump_speed = int(30 * (self._context.temperature_rate / 50.0))
-
-        if self._context.pump_speed > 30:
-            self._context.pump_speed = 30
-            # TODO: Set error flag?
-
-        # TODO: Should be based on pump speed somehow
         self._context.temperature += self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature > self._context.temperature_limit:
             self._context.temperature = self._context.temperature_limit
@@ -62,13 +52,19 @@ class DefaultCoolState(State):
         if self._context.pump_manual_mode:
             self._context.pump_speed = self._context.manual_target_speed
         else:
+            # TODO: Figure out real correlation
             self._context.pump_speed = int(30 * (self._context.temperature_rate / 50.0))
 
         if self._context.pump_speed > 30:
             self._context.pump_speed = 30
-            # TODO: Set error flag?
+            self._context.pump_overspeed = True
+        else:
+            self._context.pump_overspeed = False
 
         # TODO: Should be based on pump speed somehow
         self._context.temperature -= self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature < self._context.temperature_limit:
             self._context.temperature = self._context.temperature_limit
+
+    def on_exit(self, dt):
+        self._context.pump_overspeed = False

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -20,9 +20,14 @@
 from core import State
 
 
-class DefaultStoppedState(State):
+class DefaultInitState(State):
     def on_entry(self, dt):
         self._context.initialize()
+
+
+class DefaultStoppedState(State):
+    def on_entry(self, dt):
+        self._context.stop_commanded = False
 
 
 class DefaultStartedState(State):

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -27,14 +27,20 @@ from defaults import *
 
 class LinkamT95Context(Context):
     def initialize(self):
+        self.serial_command_mode = False
+
         self.start_commanded = False
         self.stop_commanded = False
+        self.hold_commanded = False
 
-        self.pump_speed = 0
-        self.temperature = 0.0
+        self.pump_speed = 0         # Pump speed in arbitrary unit, ranging 0 to 30
+        self.temperature = 24.0     # Current temperature in C
 
         self.pump_manual_mode = False
         self.manual_target_speed = 0
+
+        self.temperature_rate = 0.0     # Rate of change of temperature in C/min
+        self.temperature_limit = 0.0    # Target temperature in C
 
 
 class SimulatedLinkamT95(CanProcessComposite, object):
@@ -44,6 +50,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         self._context = LinkamT95Context()
 
         state_handlers = {
+            'init': DefaultInitState(),
             'stopped': DefaultStoppedState(),
             'started': DefaultStartedState(),
             'heat': DefaultHeatState(),
@@ -55,6 +62,8 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             dict_strict_update(state_handlers, override_states)
 
         transition_handlers = OrderedDict([
+            (('init', 'stopped'), lambda: self._context.serial_command_mode),
+
             (('stopped', 'started'), lambda: self._context.start_commanded),
 
             (('started', 'stopped'), lambda: self._context.stop_commanded),
@@ -79,7 +88,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             dict_strict_update(transition_handlers, override_transitions)
 
         self._csm = StateMachine({
-            'initial': 'stopped',
+            'initial': 'init',
             'states': state_handlers,
             'transitions': transition_handlers,
         }, context=self._context)
@@ -87,19 +96,51 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         self.addProcessor(self._csm)
 
     def getStatus(self):
-        return "0123456789\n" + self._csm.state + "\n"
+        self._context.serial_command_mode = True
+
+        Tarray = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "\n"]
+
+        # Status byte (SB1)
+        Tarray[0] = {
+            'stopped': 0x01,
+            'heat': 0x10,
+            'cool': 0x20,
+            'hold': 0x30,  # TODO: Other hold states
+        }.get(self._csm.state, 0x01)
+
+        # Error status byte (EB1)
+        Tarray[1] = 0x00
+
+        # Pump status byte (PB1)
+        Tarray[2] = 0x80
+
+        # Temperature
+        temphex = "%08x" % int(self._context.temperature)
+        tempbytes = [int(e) for e in [temphex[n:n+2] for n in xrange(0, len(temphex), 2)]]
+        Tarray[6:10] = tempbytes
+
+        print self._csm.state
+        return str(Tarray) + "\n"  # TODO: Should be raw bytes
 
     def setRate(self, param):
-        pass
+        rate = int(param)
+        if 1 <= rate <= 9999:
+            self._context.temperature_rate = rate / 100.0
+        print "New rate: %.2f C/min\n" % (self._context.temperature_rate,)
 
     def setLimit(self, param):
-        pass
+        limit = int(param)
+        if -9999 <= limit <= 9999:
+            self._context.temperature_limit = limit / 10.0
+        print "New limit: %.1f C\n" % (self._context.temperature_limit,)
 
     def start(self):
         self._context.start_commanded = True
+        print "Start commanded"
 
     def stop(self):
         self._context.stop_commanded = True
+        print "Stop commanded"
 
     def hold(self):
         pass

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -1,0 +1,114 @@
+#  -*- coding: utf-8 -*-
+# *********************************************************************
+# plankton - a library for creating hardware device simulators
+# Copyright (C) 2016 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+from collections import OrderedDict
+
+from core import StateMachine, CanProcessComposite, Context
+from core.utils import dict_strict_update
+
+from defaults import *
+
+
+class LinkamT95Context(Context):
+    def initialize(self):
+        self.start_commanded = False
+        self.stop_commanded = False
+
+        self.pump_speed = 0
+        self.temperature = 0.0
+
+        self.pump_manual_mode = False
+        self.manual_target_speed = 0
+
+
+class SimulatedLinkamT95(CanProcessComposite, object):
+    def __init__(self, override_states=None, override_transitions=None):
+        super(SimulatedLinkamT95, self).__init__()
+
+        self._context = LinkamT95Context()
+
+        state_handlers = {
+            'stopped': DefaultStoppedState(),
+            'started': DefaultStartedState(),
+            'heat': DefaultHeatState(),
+            'hold': DefaultHoldState(),
+            'cool': DefaultCoolState(),
+        }
+
+        if override_states is not None:
+            dict_strict_update(state_handlers, override_states)
+
+        transition_handlers = OrderedDict([
+            (('stopped', 'started'), lambda: self._context.start_commanded),
+
+            (('started', 'stopped'), lambda: self._context.stop_commanded),
+            (('started', 'heat'), lambda: False),
+            (('started', 'hold'), lambda: False),
+            (('started', 'cool'), lambda: False),
+
+            (('heat', 'hold'), lambda: False),
+            (('heat', 'cool'), lambda: False),
+            (('heat', 'stopped'), lambda: self._context.stop_commanded),
+
+            (('hold', 'heat'), lambda: False),
+            (('hold', 'cool'), lambda: False),
+            (('hold', 'stopped'), lambda: self._context.stop_commanded),
+
+            (('cool', 'heat'), lambda: False),
+            (('cool', 'hold'), lambda: False),
+            (('cool', 'stopped'), lambda: self._context.stop_commanded),
+        ])
+
+        if override_transitions is not None:
+            dict_strict_update(transition_handlers, override_transitions)
+
+        self._csm = StateMachine({
+            'initial': 'stopped',
+            'states': state_handlers,
+            'transitions': transition_handlers,
+        }, context=self._context)
+
+        self.addProcessor(self._csm)
+
+    def getStatus(self):
+        return "0123456789\n" + self._csm.state + "\n"
+
+    def setRate(self, param):
+        pass
+
+    def setLimit(self, param):
+        pass
+
+    def start(self):
+        self._context.start_commanded = True
+
+    def stop(self):
+        self._context.stop_commanded = True
+
+    def hold(self):
+        pass
+
+    def heat(self):
+        pass
+
+    def cool(self):
+        pass
+
+    def pumpCommand(self, param):
+        pass

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -135,33 +135,40 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         if 1 <= rate <= 9999:
             self._context.temperature_rate = rate / 100.0
         print "New rate: %.2f C/min" % (self._context.temperature_rate,)
+        return ""
 
     def setLimit(self, param):
         # TODO: Is not having leading zeroes / 4 digits an error?
         # TODO: What are the upper and lower limits in the real device?
         limit = int(param)
-        if -9999 <= limit <= 9999:
+        if -196 <= limit <= 1500:
             self._context.temperature_limit = limit / 10.0
         print "New limit: %.1f C" % (self._context.temperature_limit,)
+        return ""
 
     def start(self):
         self._context.start_commanded = True
         print "Start commanded"
+        return ""
 
     def stop(self):
         self._context.stop_commanded = True
         print "Stop commanded"
+        return ""
 
     def hold(self):
         self._context.hold_commanded = True
+        return ""
 
     def heat(self):
         # TODO: Is this really all it does?
         self._context.hold_commanded = False
+        return ""
 
     def cool(self):
         # TODO: Is this really all it does?
         self._context.hold_commanded = False
+        return ""
 
     def pumpCommand(self, param):
         lookup = [c for c in "0123456789:;<=>?@ABCDEFGHIJKLMN"]
@@ -172,3 +179,5 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             self._context.pump_manual_mode = True
         elif param in lookup:
             self._context.manual_target_speed = lookup.index(param)
+
+        return ""

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -73,16 +73,16 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             (('started', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
             (('started', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
 
-            (('heat', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
+            (('heat', 'hold'), lambda: self._context.temperature == self._context.temperature_limit or self._context.hold_commanded),
             (('heat', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
             (('heat', 'stopped'), lambda: self._context.stop_commanded),
 
-            (('hold', 'heat'), lambda: self._context.temperature < self._context.temperature_limit),
-            (('hold', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
+            (('hold', 'heat'), lambda: self._context.temperature < self._context.temperature_limit and not self._context.hold_commanded),
+            (('hold', 'cool'), lambda: self._context.temperature > self._context.temperature_limit and not self._context.hold_commanded),
             (('hold', 'stopped'), lambda: self._context.stop_commanded),
 
             (('cool', 'heat'), lambda: self._context.temperature < self._context.temperature_limit),
-            (('cool', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
+            (('cool', 'hold'), lambda: self._context.temperature == self._context.temperature_limit or self._context.hold_commanded),
             (('cool', 'stopped'), lambda: self._context.stop_commanded),
         ])
 

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -100,7 +100,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
     def getStatus(self):
         self._context.serial_command_mode = True
 
-        Tarray = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "\n"]
+        Tarray = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13]
 
         # Status byte (SB1)
         Tarray[0] = {
@@ -127,7 +127,9 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         Tarray[6:10] = tempbytes
 
         print self._csm.state
-        return str(Tarray) + "\n"  # TODO: Should be raw bytes
+        print str(Tarray)
+
+        return ''.join(chr(c) for c in Tarray)
 
     def setRate(self, param):
         # TODO: Is not having leading zeroes / 4 digits an error?

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -115,7 +115,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         Tarray[2] = 0x80
 
         # Temperature
-        temphex = "%08x" % int(self._context.temperature)
+        temphex = "%08x" % int(self._context.temperature * 10)
         tempbytes = [int(e, 16) for e in [temphex[n:n+2] for n in xrange(0, len(temphex), 2)]]
         Tarray[6:10] = tempbytes
 

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -100,7 +100,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
     def getStatus(self):
         self._context.serial_command_mode = True
 
-        Tarray = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13]
+        Tarray = [0x80] * 10
 
         # Status byte (SB1)
         Tarray[0] = {
@@ -113,7 +113,6 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             Tarray[0] = 0x40 if self._context.temperature == self._context.temperature_limit else 0x50
 
         # Error status byte (EB1)
-        Tarray[1] = 0x80
         if self._context.pump_overspeed:
             Tarray[1] |= 0x01
         # TODO: Add support for other error conditions?
@@ -122,9 +121,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         Tarray[2] = 0x80 + self._context.pump_speed
 
         # Temperature
-        temphex = "%08x" % int(self._context.temperature * 10)
-        tempbytes = [int(e, 16) for e in [temphex[n:n+2] for n in xrange(0, len(temphex), 2)]]
-        Tarray[6:10] = tempbytes
+        Tarray[6:10] = [x for x in "%04x" % (int(self._context.temperature * 10) & 0xFFFF)]
 
         print self._csm.state
         print str(Tarray)

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -141,7 +141,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         # TODO: Is not having leading zeroes / 4 digits an error?
         # TODO: What are the upper and lower limits in the real device?
         limit = int(param)
-        if -196 <= limit <= 1500:
+        if -1960 <= limit <= 15000:
             self._context.temperature_limit = limit / 10.0
         print "New limit: %.1f C" % (self._context.temperature_limit,)
         return ""

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -112,7 +112,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         Tarray[1] = 0x00
 
         # Pump status byte (PB1)
-        Tarray[2] = 0x80
+        Tarray[2] = 0x80 + self._context.pump_speed
 
         # Temperature
         temphex = "%08x" % int(self._context.temperature * 10)
@@ -126,13 +126,13 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         rate = int(param)
         if 1 <= rate <= 9999:
             self._context.temperature_rate = rate / 100.0
-        print "New rate: %.2f C/min\n" % (self._context.temperature_rate,)
+        print "New rate: %.2f C/min" % (self._context.temperature_rate,)
 
     def setLimit(self, param):
         limit = int(param)
         if -9999 <= limit <= 9999:
             self._context.temperature_limit = limit / 10.0
-        print "New limit: %.1f C\n" % (self._context.temperature_limit,)
+        print "New limit: %.1f C" % (self._context.temperature_limit,)
 
     def start(self):
         self._context.start_commanded = True
@@ -152,4 +152,14 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         pass
 
     def pumpCommand(self, param):
-        pass
+        if param == "a0":
+            self._context.pump_manual_mode = False
+            return
+
+        if param == "m0":
+            self._context.pump_manual_mode = True
+            return
+
+        lookup = [c for c in "0123456789:;<=>?@ABCDEFGHIJKLMN"]
+        if param in lookup:
+            self._context.manual_target_speed = lookup.index(param)

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -121,7 +121,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         Tarray[2] = 0x80 + self._context.pump_speed
 
         # Temperature
-        Tarray[6:10] = [x for x in "%04x" % (int(self._context.temperature * 10) & 0xFFFF)]
+        Tarray[6:10] = [ord(x) for x in "%04x" % (int(self._context.temperature * 10) & 0xFFFF)]
 
         print self._csm.state
         print str(Tarray)

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -67,20 +67,20 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             (('stopped', 'started'), lambda: self._context.start_commanded),
 
             (('started', 'stopped'), lambda: self._context.stop_commanded),
-            (('started', 'heat'), lambda: False),
-            (('started', 'hold'), lambda: False),
-            (('started', 'cool'), lambda: False),
+            (('started', 'heat'), lambda: self._context.temperature < self._context.temperature_limit),
+            (('started', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
+            (('started', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
 
-            (('heat', 'hold'), lambda: False),
-            (('heat', 'cool'), lambda: False),
+            (('heat', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
+            (('heat', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
             (('heat', 'stopped'), lambda: self._context.stop_commanded),
 
-            (('hold', 'heat'), lambda: False),
-            (('hold', 'cool'), lambda: False),
+            (('hold', 'heat'), lambda: self._context.temperature < self._context.temperature_limit),
+            (('hold', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
             (('hold', 'stopped'), lambda: self._context.stop_commanded),
 
-            (('cool', 'heat'), lambda: False),
-            (('cool', 'hold'), lambda: False),
+            (('cool', 'heat'), lambda: self._context.temperature < self._context.temperature_limit),
+            (('cool', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
             (('cool', 'stopped'), lambda: self._context.stop_commanded),
         ])
 
@@ -116,7 +116,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
 
         # Temperature
         temphex = "%08x" % int(self._context.temperature)
-        tempbytes = [int(e) for e in [temphex[n:n+2] for n in xrange(0, len(temphex), 2)]]
+        tempbytes = [int(e, 16) for e in [temphex[n:n+2] for n in xrange(0, len(temphex), 2)]]
         Tarray[6:10] = tempbytes
 
         print self._csm.state

--- a/setups/linkam_t95/__init__.py
+++ b/setups/linkam_t95/__init__.py
@@ -16,6 +16,3 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
-
-from chopper import SimulatedChopper
-from linkam_t95 import SimulatedLinkamT95

--- a/setups/linkam_t95/bindings.py
+++ b/setups/linkam_t95/bindings.py
@@ -20,8 +20,8 @@
 
 stream = {
     'meta': {
-        'in_terminator': "\n",
-        'out_terminator': "\n",
+        'in_terminator': "\r",
+        'out_terminator': "\r",
     },
 
     'commands': {

--- a/setups/linkam_t95/bindings.py
+++ b/setups/linkam_t95/bindings.py
@@ -17,5 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from chopper import SimulatedChopper
-from linkam_t95 import SimulatedLinkamT95
+
+stream = {
+    'T': 'getStatus',
+    'R1': 'setRate',
+    'L1': 'setLimit',
+    'S': 'start',
+    'E': 'stop',
+    'O': 'hold',
+    'H': 'heat',
+    'C': 'cool',
+    'P': 'pumpCommand',
+}

--- a/setups/linkam_t95/bindings.py
+++ b/setups/linkam_t95/bindings.py
@@ -19,13 +19,20 @@
 
 
 stream = {
-    'T': 'getStatus',
-    'R1': 'setRate',
-    'L1': 'setLimit',
-    'S': 'start',
-    'E': 'stop',
-    'O': 'hold',
-    'H': 'heat',
-    'C': 'cool',
-    'P': 'pumpCommand',
+    'meta': {
+        'in_terminator': "\n",
+        'out_terminator': "\n",
+    },
+
+    'commands': {
+        'T': 'getStatus',
+        'R1': 'setRate',
+        'L1': 'setLimit',
+        'S': 'start',
+        'E': 'stop',
+        'O': 'hold',
+        'H': 'heat',
+        'C': 'cool',
+        'P': 'pumpCommand',
+    }
 }

--- a/setups/linkam_t95/default.py
+++ b/setups/linkam_t95/default.py
@@ -17,5 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from chopper import SimulatedChopper
-from linkam_t95 import SimulatedLinkamT95
+from devices import SimulatedLinkamT95
+
+linkam = SimulatedLinkamT95()

--- a/simulation.py
+++ b/simulation.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #  -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators


### PR DESCRIPTION
Closes #53 and #56.

This PR implements a Linkam T95 Temperature Controller. Behaviour is still very rudimentary and some features aren't fully implemented. But basic behaviour is provided and IBEX can interact with it sufficiently to serve as a basic for further development to refine behaviour and fill in edge cases.

This PR also implements a TCP Stream adapter to allow the Linkam to communicate with the IOC used by IBEX. Currently the port it listens on is fixed to 9999. This should be addressed once some other issues with the startup process are resolved (see #70, #71).

Unit tests should be added in a separate issue.
