### PR TITLE
ArgumentParsers for Adapters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM dmscid/epics-pcaspy:latest
 
-COPY . /plankton
+COPY requirements*.txt /plankton/
 
 RUN pip install -r plankton/requirements.txt && \
     pip install -r plankton/requirements-dev.txt
+
+COPY . /plankton
 
 ENTRYPOINT ["/init.sh", "/plankton/simulation.py"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM dmscid/epics-pcaspy:latest
 
+# Copying these separately from the rest of plankton allows the
+# pip install step to be cached until the requirements change.
+# Rebuilding is faster and doesn't require an internet connection.
 COPY requirements*.txt /plankton/
 
 RUN pip install -r plankton/requirements.txt && \

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -18,10 +18,18 @@
 # *********************************************************************
 
 import importlib
+import argparse
 
 
 class Adapter(object):
+    def _parseArguments(self, arguments):
+        return argparse.Namespace()
+
     def run(self, target, bindings, arguments):
+        options = self._parseArguments(arguments)
+        self.doRun(target, bindings, **vars(options))
+
+    def doRun(self, target, bindings, **options):
         pass
 
 

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -22,14 +22,7 @@ import argparse
 
 
 class Adapter(object):
-    def _parseArguments(self, arguments):
-        return argparse.Namespace()
-
     def run(self, target, bindings, arguments):
-        options = self._parseArguments(arguments)
-        self.doRun(target, bindings, **vars(options))
-
-    def doRun(self, target, bindings, **options):
         pass
 
 

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -21,7 +21,7 @@ import importlib
 
 
 class Adapter(object):
-    def run(cls, target, bindings, *args, **kwargs):
+    def run(self, target, bindings, arguments):
         pass
 
 

--- a/adapters/epics.py
+++ b/adapters/epics.py
@@ -74,9 +74,11 @@ class EpicsAdapter(Adapter):
         parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
         return parser.parse_args(arguments)
 
-    def run(self, target, bindings, prefix):
+    def run(self, target, bindings, arguments):
+        options = self._parseArguments(arguments)
+
         server = SimpleServer()
-        server.createPV(prefix=prefix, pvdb=bindings)
+        server.createPV(prefix=options.prefix, pvdb=bindings)
         driver = PropertyExposingDriver(target=target, pv_dict=bindings)
 
         delta = 0.0  # Delta between cycles

--- a/adapters/epics.py
+++ b/adapters/epics.py
@@ -70,7 +70,6 @@ class PropertyExposingDriver(CanProcess, Driver):
 
 class EpicsAdapter(Adapter):
     def run(self, target, bindings, arguments):
-        print arguments
         parser = ArgumentParser(description="Adapter to expose a device via EPICS")
         parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
         arguments = parser.parse_args(arguments)

--- a/adapters/epics.py
+++ b/adapters/epics.py
@@ -18,6 +18,7 @@
 # *********************************************************************
 
 from datetime import datetime
+from argparse import ArgumentParser
 
 from pcaspy import Driver, SimpleServer
 
@@ -68,9 +69,14 @@ class PropertyExposingDriver(CanProcess, Driver):
 
 
 class EpicsAdapter(Adapter):
-    def run(self, target, bindings, *args, **kwargs):
+    def run(self, target, bindings, arguments):
+        print arguments
+        parser = ArgumentParser(description="Adapter to expose a device via EPICS")
+        parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
+        arguments = parser.parse_args(arguments)
+
         server = SimpleServer()
-        server.createPV(prefix=kwargs['pv_prefix'], pvdb=bindings)
+        server.createPV(prefix=arguments.prefix, pvdb=bindings)
         driver = PropertyExposingDriver(target=target, pv_dict=bindings)
 
         delta = 0.0  # Delta between cycles

--- a/adapters/epics.py
+++ b/adapters/epics.py
@@ -69,13 +69,14 @@ class PropertyExposingDriver(CanProcess, Driver):
 
 
 class EpicsAdapter(Adapter):
-    def run(self, target, bindings, arguments):
+    def _parseArguments(self, arguments):
         parser = ArgumentParser(description="Adapter to expose a device via EPICS")
         parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
-        arguments = parser.parse_args(arguments)
+        return parser.parse_args(arguments)
 
+    def run(self, target, bindings, prefix):
         server = SimpleServer()
-        server.createPV(prefix=arguments.prefix, pvdb=bindings)
+        server.createPV(prefix=prefix, pvdb=bindings)
         driver = PropertyExposingDriver(target=target, pv_dict=bindings)
 
         delta = 0.0  # Delta between cycles

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -76,7 +76,10 @@ class StreamServer(asyncore.dispatcher):
 
 
 class StreamAdapter(Adapter):
-    def run(self, target, bindings, *args, **kwargs):
+    def run(self, target, bindings, arguments):
+        if arguments:
+            raise RuntimeError("Unknown TCP stream adapter argument: %s" % arguments[0])
+
         StreamServer("0.0.0.0", 9999, target, bindings)
 
         delta = 0.0  # Delta between cycles

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -77,13 +77,15 @@ class StreamServer(asyncore.dispatcher):
 
 
 class StreamAdapter(Adapter):
-    def run(self, target, bindings, arguments):
+    def _parseArguments(self, arguments):
         parser = ArgumentParser(description='Adapter to expose a device via TCP Stream')
-        parser.add_argument('-b', '--bind-address', help='IP Address to bind and listen for connections on', default='0.0.0.0')
+        parser.add_argument('-b', '--bind-address', help='IP Address to bind and listen for connections on',
+                            default='0.0.0.0')
         parser.add_argument('-p', '--port', help='Port to listen for connections on', type=int, default=9999)
-        arguments = parser.parse_args(arguments)
+        return parser.parse_args(arguments)
 
-        StreamServer(arguments.bind_address, arguments.port, target, bindings)
+    def doRun(self, target, bindings, bind_address, port):
+        StreamServer(bind_address, port, target, bindings)
 
         delta = 0.0  # Delta between cycles
         count = 0  # Cycles per second counter

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -23,6 +23,7 @@ import asynchat
 import socket
 
 from adapters import Adapter
+from argparse import ArgumentParser
 from datetime import datetime
 
 
@@ -77,10 +78,12 @@ class StreamServer(asyncore.dispatcher):
 
 class StreamAdapter(Adapter):
     def run(self, target, bindings, arguments):
-        if arguments:
-            raise RuntimeError("Unknown TCP stream adapter argument: %s" % arguments[0])
+        parser = ArgumentParser(description='Adapter to expose a device via TCP Stream')
+        parser.add_argument('-b', '--bind-address', help='IP Address to bind and listen for connections on', default='0.0.0.0')
+        parser.add_argument('-p', '--port', help='Port to listen for connections on', type=int, default=9999)
+        arguments = parser.parse_args(arguments)
 
-        StreamServer("0.0.0.0", 9999, target, bindings)
+        StreamServer(arguments.bind_address, arguments.port, target, bindings)
 
         delta = 0.0  # Delta between cycles
         count = 0  # Cycles per second counter

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -84,8 +84,10 @@ class StreamAdapter(Adapter):
         parser.add_argument('-p', '--port', help='Port to listen for connections on', type=int, default=9999)
         return parser.parse_args(arguments)
 
-    def doRun(self, target, bindings, bind_address, port):
-        StreamServer(bind_address, port, target, bindings)
+    def run(self, target, bindings, arguments):
+        options = self._parseArguments(arguments)
+
+        StreamServer(options.bind_address, options.port, target, bindings)
 
         delta = 0.0  # Delta between cycles
         count = 0  # Cycles per second counter

--- a/simulation.py
+++ b/simulation.py
@@ -56,8 +56,7 @@ parser.add_argument('-p', '--protocol', help='Communication protocol to expose d
 parser.add_argument('-a', '--adapter',
                     help='Name of adapter class. If not specified, the loader will choose '
                          'the first adapter it discovers.')
-parser.add_argument('--parameters', help='Additional parameters for the protocol, key=value pairs separated by comma.',
-                    action=StoreNameValuePairs)
+parser.add_argument('adapter_args', nargs='*', help='Arguments for the adapter.')
 
 arguments = parser.parse_args()
 
@@ -67,4 +66,4 @@ bindings = import_bindings(arguments.device, arguments.protocol if arguments.bin
 device = import_device(arguments.device, arguments.setup)
 
 adapter = CommunicationAdapter()
-adapter.run(device, bindings, **arguments.parameters)
+adapter.run(device, bindings, arguments.adapter_args)

--- a/simulation.py
+++ b/simulation.py
@@ -24,26 +24,6 @@ from adapters import import_adapter
 from setups import import_device, import_bindings
 
 
-class StoreNameValuePairs(argparse.Action):
-    """
-    This class is a slightly modified version of the solution presented in a stackoverflow answer:
-        http://stackoverflow.com/a/11762020
-    """
-
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        super(StoreNameValuePairs, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
-
-        self._param_name = dest
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        option_dict = {}
-        for option in values.split(','):
-            n, v = option.split('=')
-            option_dict[n] = v
-
-        setattr(namespace, self._param_name, option_dict)
-
-
 parser = argparse.ArgumentParser(
     description='Run a simulated device and expose it via a specified communication protocol.')
 parser.add_argument('-d', '--device', help='Name of the device to simulate.', default='chopper',


### PR DESCRIPTION
Closes #71.

This PR adds `ArgumentParser`s to the adapters and modifies startup such that general plankton arguments are handled in `simulation.py` and the remainders is passed on to the adapter. 

Plankton arguments should be separated from adapter arguments by a `--`.

Generally, Plankton should now be invoked as follows:

```
# docker run -it dmscid/plankton -d device_name -p {epics|stream} [-- [adapter arg] [...]]
```

Stream Adapter: Added `-p/--port` and `-b/--bind-address` arguments. Port defaults to 9999 and address to `0.0.0.0` (listen on all network adapters).

EPICS Adapter: The previous `--parameters pv_prefix=SIM:` now becomes `-- -p SIM:` or `-- --prefix SIM:`. It defaults to an empty string.

Examples:

```
# docker run -it dmscid/plankton -d chopper -p epics
# docker run -it dmscid/plankton -d chopper -p epics -- -p SIM1:
# docker run -it dmscid/plankton -d chopper -p epics -- --prefix SIM2:
# docker run -it dmscid/plankton -d linkam_t95 -p stream
# docker run -it dmscid/plankton -d linkam_t95 -p stream -- --bind-address localhost
# docker run -it -p 9999:1234 dmscid/plankton -d linkam_t95 -p stream -- -b 172.17.0.2 --port 1234
```
