### PR TITLE
Starting chopper with target speed 0 should stop it instead

### DIFF
--- a/devices/chopper/device.py
+++ b/devices/chopper/device.py
@@ -209,7 +209,10 @@ class SimulatedChopper(CanProcessComposite, object):
 
     # Accelerating stuff
     def start(self):
-        self._context.start_commanded = True
+        if self._context.target_speed > 0.0:
+            self._context.start_commanded = True
+        else:
+            self.stop()
 
     @property
     def started(self):


### PR DESCRIPTION
This fixes #66.

The behavior has been implemented so that the `start`-method invokes the `stop`-method of the device if the target speed is 0. There are different ways to do this, for example changing the condition that needs to be true for transitioning into the `stopping`-state, but that requires more changes. Also, with this implementation it doesn't matter if the stopping mechanism changes.

To test you could bring the chopper to an arbitrary speed and phase and then set the target to 0 and start it. Instead of going to `accelerating`, the state should be `stopping`.

One problem this highlights is the "remember all commands ever issued" behavior. If the chopper is already stopped, the `stop_commanded`-switch is still set (this is not strictly related to this issue or the way the solution is implemented, it was there before). I don't think this is how the CHIC works for this particular case, I'll check with Andres. I think the `stop`-method should contain a check `if self._csm.state != 'stopped'` or something like that.
