### PR TITLE
Linkam T95 Documentation

### DIFF
--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -37,6 +37,7 @@ class DefaultStartedState(State):
 
 class DefaultHeatState(State):
     def in_state(self, dt):
+        # Approach target temperature as set temperature rate
         self._context.temperature += self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature > self._context.temperature_limit:
             self._context.temperature = self._context.temperature_limit
@@ -48,12 +49,14 @@ class DefaultHoldState(State):
 
 class DefaultCoolState(State):
     def in_state(self, dt):
+        # TODO: Does manual control work like this? Or is it perhaps a separate state?
         if self._context.pump_manual_mode:
             self._context.pump_speed = self._context.manual_target_speed
         else:
             # TODO: Figure out real correlation
             self._context.pump_speed = 30 * (self._context.temperature_rate / 50.0)
 
+        # Handle "cooling too fast" error
         if self._context.pump_speed > 30:
             self._context.pump_speed = 30
             self._context.pump_overspeed = True
@@ -67,5 +70,6 @@ class DefaultCoolState(State):
             self._context.temperature = self._context.temperature_limit
 
     def on_exit(self, dt):
+        # If we exit the cooling state, the cooling pump should no longer run
         self._context.pump_overspeed = False
         self._context.pump_speed = 0

--- a/devices/linkam_t95/defaults.py
+++ b/devices/linkam_t95/defaults.py
@@ -21,23 +21,24 @@ from core import State
 
 
 class DefaultInitState(State):
-    def on_entry(self, dt):
-        self._context.initialize()
+    pass
 
 
 class DefaultStoppedState(State):
     def on_entry(self, dt):
+        # Reset the stop commanded flag once we enter the stopped state
         self._context.stop_commanded = False
 
 
 class DefaultStartedState(State):
     def on_entry(self, dt):
+        # Reset the start commanded flag once we enter the started state
         self._context.start_commanded = False
 
 
 class DefaultHeatState(State):
     def in_state(self, dt):
-        # Approach target temperature as set temperature rate
+        # Approach target temperature at set temperature rate
         self._context.temperature += self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature > self._context.temperature_limit:
             self._context.temperature = self._context.temperature_limit
@@ -64,6 +65,7 @@ class DefaultCoolState(State):
             self._context.pump_speed = int(self._context.pump_speed)
             self._context.pump_overspeed = False
 
+        # Approach target temperature at set temperature rate
         # TODO: Should be based on pump speed somehow
         self._context.temperature -= self._context.temperature_rate * (dt / 60.0)
         if self._context.temperature < self._context.temperature_limit:

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -26,7 +26,26 @@ from defaults import *
 
 
 class LinkamT95Context(Context):
+    """
+    The Context models device memory state.
+
+    All the variables that the device tracks should be defined here, and
+    initialized to default values.
+
+    The device context is available as _context in the device class, and
+    all associated device State and Transition classes.
+    """
     def initialize(self):
+        """
+        This method is called once on construction. After that, it may be
+        manually called again to reset the device to its default state.
+
+        After the first call during construction, the class is frozen.
+
+        This means that attempting to define a new member variable will
+        raise an exception. This is to prevent typos from inadvertently
+        and silently adding new members instead of accessing existing ones.
+        """
         self.serial_command_mode = False
         self.pump_overspeed = False
 
@@ -49,8 +68,10 @@ class SimulatedLinkamT95(CanProcessComposite, object):
     def __init__(self, override_states=None, override_transitions=None):
         super(SimulatedLinkamT95, self).__init__()
 
+        # Create instance of device context. This is shared with all the states of this device.
         self._context = LinkamT95Context()
 
+        # Define all existing states of the device; the handlers live in defaults.py
         state_handlers = {
             'init': DefaultInitState(),
             'stopped': DefaultStoppedState(),
@@ -60,9 +81,11 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             'cool': DefaultCoolState(),
         }
 
+        # Allows setup to override state behaviour by passing it to this constructor
         if override_states is not None:
             dict_strict_update(state_handlers, override_states)
 
+        # Define all transitions and the conditions under which they are executed.
         transition_handlers = OrderedDict([
             (('init', 'stopped'), lambda: self._context.serial_command_mode),
 
@@ -86,6 +109,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             (('cool', 'stopped'), lambda: self._context.stop_commanded),
         ])
 
+        # Allows setup to override transition behaviour by passing it to this constructor
         if override_transitions is not None:
             dict_strict_update(transition_handlers, override_transitions)
 
@@ -95,9 +119,19 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             'transitions': transition_handlers,
         }, context=self._context)
 
+        # Ensures the state machine object gets a 'process' heartbeat tick
         self.addProcessor(self._csm)
 
     def getStatus(self):
+        """
+        Models "T Command" functionality of device.
+
+        Returns all available status information about the device as single byte array.
+
+        :return: Byte array consisting of 10 status bytes.
+        """
+
+        # "The first command sent must be a 'T' command" from T95 manual
         self._context.serial_command_mode = True
 
         Tarray = [0x80] * 10
@@ -129,6 +163,14 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         return ''.join(chr(c) for c in Tarray)
 
     def setRate(self, param):
+        """
+        Models "Rate Command" functionality of device.
+
+        Sets the target rate of temperature change.
+
+        :param param: Rate of temperature change in C/min, multiplied by 100, as a string. Must be positive.
+        :return: Empty string.
+        """
         # TODO: Is not having leading zeroes / 4 digits an error?
         # TODO: What is the upper limit in the real device?
         rate = int(param)
@@ -138,6 +180,14 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         return ""
 
     def setLimit(self, param):
+        """
+        Models "Limit Command" functionality of device.
+
+        Sets the target temperate to be reached.
+
+        :param param: Target temperature in C, multiplied by 10, as a string. Can be negative.
+        :return: Empty string.
+        """
         # TODO: Is not having leading zeroes / 4 digits an error?
         # TODO: What are the upper and lower limits in the real device?
         limit = int(param)
@@ -147,30 +197,69 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         return ""
 
     def start(self):
+        """
+        Models "Start Command" functionality of device.
+
+        Tells the T95 unit to start heating or cooling at the rate specified by setRate and to a limit set by setLimit.
+
+        :return: Empty string.
+        """
         self._context.start_commanded = True
         print "Start commanded"
         return ""
 
     def stop(self):
+        """
+        Models "Stop Command" functionality of device.
+
+        Tells the T95 unit to stop heating or cooling.
+
+        :return: Empty string.
+        """
         self._context.stop_commanded = True
         print "Stop commanded"
         return ""
 
     def hold(self):
+        """
+        Models "Hold Command" functionality of device.
+
+        Device will hold current temperature until a heat or cool command is issued.
+
+        :return: Empty string.
+        """
         self._context.hold_commanded = True
         return ""
 
     def heat(self):
+        """
+        Models "Heat Command" functionality of device.
+
+        :return: Empty string.
+        """
         # TODO: Is this really all it does?
         self._context.hold_commanded = False
         return ""
 
     def cool(self):
+        """
+        Models "Cool Command" functionality of device.
+
+        :return: Empty string.
+        """
         # TODO: Is this really all it does?
         self._context.hold_commanded = False
         return ""
 
     def pumpCommand(self, param):
+        """
+        Models "LNP Pump Commands" functionality of device.
+
+        Switches between automatic or manual pump mode, and adjusts speed when in manual mode.
+
+        :param param: 'a0' for auto, 'm0' for manual, [0-N] for speed.
+        :return:
+        """
         lookup = [c for c in "0123456789:;<=>?@ABCDEFGHIJKLMN"]
 
         if param == "a0":


### PR DESCRIPTION
Closes #76.

Added inline and docstring documentation to the Linkam device and state handlers.
