### PR TITLE
Make plankton compatible with Python 2 & 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 
 python:
   - "2.7"
+  - "3.5"
 install:
   - pip install -r requirements-dev.txt
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 # Plankton
 
-Plankton is a library that assists in building simulated hardware devices. Currently this repository contains
-a simulated neutron chopper as it will be present at [ESS](http://europeanspallationsource.se).
+Plankton is a Python library that assists in building simulated hardware devices. It is compatible with both Python 2 and 3.
+Currently this repository contains a simulated neutron chopper as it will be present at [ESS](http://europeanspallationsource.se).
 Choppers at ESS are abstracted in such a way that all of them are exposed via the same interface,
 regardless of manufacturer. The behavior of this abstraction layer can be modelled as a finite state machine.
 

--- a/adapters/epics.py
+++ b/adapters/epics.py
@@ -17,6 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+from __future__ import print_function
+from six import iteritems
+
 from datetime import datetime
 from argparse import ArgumentParser
 
@@ -56,7 +59,7 @@ class PropertyExposingDriver(CanProcess, Driver):
 
     def doProcess(self, dt):
         # Updates bound parameters as needed
-        for pv, parameters in self._pv_dict.iteritems():
+        for pv, parameters in iteritems(self._pv_dict):
             self._timers[pv] += dt
             if self._timers[pv] >= parameters.get('poll_interval', self._default_poll_interval):
                 try:
@@ -100,6 +103,6 @@ class EpicsAdapter(Adapter):
             count += 1
             timer += delta
             if timer >= 1.0:
-                print "Running at %d cycles per second (%.3f ms per cycle)" % (count, 1000.0 / count)
+                print("Running at %d cycles per second (%.3f ms per cycle)" % (count, 1000.0 / count))
                 count = 0
                 timer = 0.0

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+from __future__ import print_function
+from six import iteritems
 
 import asyncore
 import asynchat
@@ -43,7 +45,7 @@ class StreamHandler(asynchat.async_chat):
         reply = None
         self.buffer = []
 
-        for command, funcname in self.bindings['commands'].iteritems():
+        for command, funcname in iteritems(self.bindings['commands']):
             if request.startswith(command):
                 func = getattr(self.target, funcname)
                 args = request[len(command):]
@@ -72,7 +74,7 @@ class StreamServer(asyncore.dispatcher):
         pair = self.accept()
         if pair is not None:
             sock, addr = pair
-            print "Client connect from %s" % repr(addr)
+            print("Client connect from %s" % repr(addr))
             StreamHandler(sock, self.target, self.bindings)
 
 
@@ -103,6 +105,6 @@ class StreamAdapter(Adapter):
             count += 1
             timer += delta
             if timer >= 1.0:
-                print "Running at %d cycles per second (%.3f ms per cycle)" % (count, 1000.0 / count)
+                print("Running at %d cycles per second (%.3f ms per cycle)" % (count, 1000.0 / count))
                 count = 0
                 timer = 0.0

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,5 +17,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from statemachine import StateMachine, State, Transition, Context
-from processor import CanProcess, CanProcessComposite
+from .statemachine import StateMachine, State, Transition, Context
+from .processor import CanProcess, CanProcessComposite

--- a/core/statemachine.py
+++ b/core/statemachine.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+from six import iteritems
 from core.processor import CanProcess
 
 
@@ -72,6 +73,7 @@ class HasContext(object):
     receive a context from its StateMachine upon initialization (assuming the
     StateMachine was provided with a context itself).
     """
+
     def __init__(self):
         super(HasContext, self).__init__()
         self._context = None
@@ -91,6 +93,7 @@ class State(HasContext):
     To use this class, create a derived class and override any events that need
     custom behaviour. Device context is provided via HasContext mixin.
     """
+
     def __init__(self):
         super(State, self).__init__()
 
@@ -133,6 +136,7 @@ class Transition(HasContext):
 
     To use this class, create a derived class and override the __call__ attribute.
     """
+
     def __init__(self):
         super(Transition, self).__init__()
 
@@ -202,7 +206,7 @@ class StateMachine(CanProcess):
         self._set_handlers(self._initial)
 
         # Allow user to explicitly specify state handlers
-        for state_name, handlers in cfg.get('states', {}).iteritems():
+        for state_name, handlers in iteritems(cfg.get('states', {})):
             if isinstance(handlers, HasContext):
                 handlers.setContext(context)
 
@@ -219,7 +223,7 @@ class StateMachine(CanProcess):
                 raise StateMachineException(
                     "Failed to parse state handlers for state '%s'. Must be dict or iterable." % state_name)
 
-        for states, check_func in cfg.get('transitions', {}).iteritems():
+        for states, check_func in iteritems(cfg.get('transitions', {})):
             from_state, to_state = states
 
             # Set up default handlers if this state hasn't been mentioned before
@@ -275,8 +279,8 @@ class StateMachine(CanProcess):
         prefix = dict(list(self._prefix.items()) + list(prefix.items()))
 
         # Bind handlers
-        for state, handlers in self._handler.iteritems():
-            for event, handler in handlers.iteritems():
+        for state, handlers in iteritems(self._handler):
+            for event, handler in iteritems(handlers):
                 if handler is None or override:
                     named_handler = getattr(instance, prefix[event] + state, None)
                     if callable(named_handler):

--- a/core/utils.py
+++ b/core/utils.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-import importlib
 import imp
 import os.path as osp
 from os import listdir
@@ -94,7 +93,7 @@ def dict_strict_update(base_dict, update_dict):
     :param base_dict: The dict that is to be updated. This dict is modified.
     :param update_dict: The dict containing the new values.
     """
-    additional_keys = update_dict.viewkeys() - base_dict.viewkeys()
+    additional_keys = set(update_dict.keys()) - set(base_dict.keys())
     if len(additional_keys) > 0:
         raise RuntimeError(
             'The update dictionary contains keys that are not part of the base dictionary: {}'.format(

--- a/devices/__init__.py
+++ b/devices/__init__.py
@@ -17,5 +17,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from chopper import SimulatedChopper
-from linkam_t95 import SimulatedLinkamT95
+from .chopper import SimulatedChopper
+from .linkam_t95 import SimulatedLinkamT95

--- a/devices/chopper/__init__.py
+++ b/devices/chopper/__init__.py
@@ -17,5 +17,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from device import SimulatedChopper
-from defaults import *
+from .device import SimulatedChopper
+from .defaults import *

--- a/devices/chopper/device.py
+++ b/devices/chopper/device.py
@@ -22,8 +22,8 @@ from collections import OrderedDict
 from core import StateMachine, CanProcessComposite, CanProcess, Context
 from core.utils import dict_strict_update
 
-from bearings import MagneticBearings
-from defaults import *
+from .bearings import MagneticBearings
+from .defaults import *
 
 
 class SimulatedBearings(CanProcess, MagneticBearings):

--- a/devices/linkam_t95/__init__.py
+++ b/devices/linkam_t95/__init__.py
@@ -17,6 +17,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from device import SimulatedLinkamT95
-from defaults import *
-
+from .device import SimulatedLinkamT95
+from .defaults import *

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -17,12 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+from __future__ import print_function
 from collections import OrderedDict
 
 from core import StateMachine, CanProcessComposite, Context
 from core.utils import dict_strict_update
 
-from defaults import *
+from .defaults import *
 
 
 class LinkamT95Context(Context):
@@ -35,6 +36,7 @@ class LinkamT95Context(Context):
     The device context is available as _context in the device class, and
     all associated device State and Transition classes.
     """
+
     def initialize(self):
         """
         This method is called once on construction. After that, it may be
@@ -54,11 +56,11 @@ class LinkamT95Context(Context):
         self.hold_commanded = False
 
         # TODO: Actual rate and limit defaults?
-        self.temperature_rate = 0.01    # Rate of change of temperature in C/min
-        self.temperature_limit = 0.0    # Target temperature in C
+        self.temperature_rate = 0.01  # Rate of change of temperature in C/min
+        self.temperature_limit = 0.0  # Target temperature in C
 
-        self.pump_speed = 0         # Pump speed in arbitrary unit, ranging 0 to 30
-        self.temperature = 24.0     # Current temperature in C
+        self.pump_speed = 0  # Pump speed in arbitrary unit, ranging 0 to 30
+        self.temperature = 24.0  # Current temperature in C
 
         self.pump_manual_mode = False
         self.manual_target_speed = 0
@@ -96,16 +98,20 @@ class SimulatedLinkamT95(CanProcessComposite, object):
             (('started', 'hold'), lambda: self._context.temperature == self._context.temperature_limit),
             (('started', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
 
-            (('heat', 'hold'), lambda: self._context.temperature == self._context.temperature_limit or self._context.hold_commanded),
+            (('heat', 'hold'),
+             lambda: self._context.temperature == self._context.temperature_limit or self._context.hold_commanded),
             (('heat', 'cool'), lambda: self._context.temperature > self._context.temperature_limit),
             (('heat', 'stopped'), lambda: self._context.stop_commanded),
 
-            (('hold', 'heat'), lambda: self._context.temperature < self._context.temperature_limit and not self._context.hold_commanded),
-            (('hold', 'cool'), lambda: self._context.temperature > self._context.temperature_limit and not self._context.hold_commanded),
+            (('hold', 'heat'),
+             lambda: self._context.temperature < self._context.temperature_limit and not self._context.hold_commanded),
+            (('hold', 'cool'),
+             lambda: self._context.temperature > self._context.temperature_limit and not self._context.hold_commanded),
             (('hold', 'stopped'), lambda: self._context.stop_commanded),
 
             (('cool', 'heat'), lambda: self._context.temperature < self._context.temperature_limit),
-            (('cool', 'hold'), lambda: self._context.temperature == self._context.temperature_limit or self._context.hold_commanded),
+            (('cool', 'hold'),
+             lambda: self._context.temperature == self._context.temperature_limit or self._context.hold_commanded),
             (('cool', 'stopped'), lambda: self._context.stop_commanded),
         ])
 
@@ -157,8 +163,8 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         # Temperature
         Tarray[6:10] = [ord(x) for x in "%04x" % (int(self._context.temperature * 10) & 0xFFFF)]
 
-        print self._csm.state
-        print str(Tarray)
+        print(self._csm.state)
+        print(str(Tarray))
 
         return ''.join(chr(c) for c in Tarray)
 
@@ -176,7 +182,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         rate = int(param)
         if 1 <= rate <= 9999:
             self._context.temperature_rate = rate / 100.0
-        print "New rate: %.2f C/min" % (self._context.temperature_rate,)
+        print("New rate: %.2f C/min" % (self._context.temperature_rate,))
         return ""
 
     def setLimit(self, param):
@@ -193,7 +199,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         limit = int(param)
         if -1960 <= limit <= 15000:
             self._context.temperature_limit = limit / 10.0
-        print "New limit: %.1f C" % (self._context.temperature_limit,)
+        print("New limit: %.1f C" % (self._context.temperature_limit,))
         return ""
 
     def start(self):
@@ -205,7 +211,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         :return: Empty string.
         """
         self._context.start_commanded = True
-        print "Start commanded"
+        print("Start commanded")
         return ""
 
     def stop(self):
@@ -217,7 +223,7 @@ class SimulatedLinkamT95(CanProcessComposite, object):
         :return: Empty string.
         """
         self._context.stop_commanded = True
-        print "Stop commanded"
+        print("Stop commanded")
         return ""
 
     def hold(self):

--- a/setups/__init__.py
+++ b/setups/__init__.py
@@ -68,6 +68,8 @@ def import_bindings(device_type, bindings_type):
     :param bindings_type: Name of the variable to import as bindings
     :return: Variable that specifies the binding.
     """
-    module = importlib.import_module('.bindings', 'setups.{}'.format(device_type))
+    package_name = 'setups.{}'.format(device_type)
+    importlib.import_module(package_name)
+    module = importlib.import_module('.bindings', package_name)
 
     return getattr(module, bindings_type)

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -18,7 +18,11 @@
 # *********************************************************************
 
 import unittest
-from mock import call, patch
+
+try:
+    from unittest.mock import call, patch
+except ImportError:
+    from mock import call, patch
 
 from core.processor import CanProcess, CanProcessComposite
 

--- a/test/test_StateMachine.py
+++ b/test/test_StateMachine.py
@@ -18,7 +18,11 @@
 # *********************************************************************
 
 import unittest
-from mock import Mock, patch
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from core.statemachine import StateMachine, State, Transition, Context
 from core.statemachine import StateMachineException

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+from six import iteritems
 import unittest
 
 from core.utils import dict_strict_update
@@ -77,21 +78,21 @@ class TestWithPackageStructure(unittest.TestCase):
         cls._tmp_package_name = os.path.basename(cls._tmp_package)
         cls._tmp_dir = tempfile.gettempdir()
 
-        cls._files = {k: os.path.join(cls._tmp_package, v) for k, v in dict(
+        cls._files = {k: os.path.join(cls._tmp_package, v) for k, v in iteritems(dict(
             valid='some_file.py',
             invalid_ext='some_other_file.pyc',
             invalid_name='_some_invalid_file.py',
-        ).iteritems()}
+        ))}
 
         for abs_file_name in cls._files.values():
             with open(abs_file_name, mode='w'):
                 pass
 
-        cls._dirs = {k: os.path.join(cls._tmp_package, v) for k, v in dict(
+        cls._dirs = {k: os.path.join(cls._tmp_package, v) for k, v in iteritems(dict(
             valid='some_dir',
             empty='empty_dir',
             invalid='_invalid',
-        ).iteritems()}
+        ))}
 
         for abs_dir_name in cls._dirs.values():
             os.mkdir(abs_dir_name)


### PR DESCRIPTION
This fixes #75.

The changes in this branch make plankton run in both Python 2 & 3. To run the tests on Ubuntu, you can run `nosetests` and `nosetests3` in the plankton directory. You could also start the two devices manually to check that they are still running.
