### PR TITLE
Strip newlines from StreamHandler

### DIFF
--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -41,7 +41,7 @@ class StreamHandler(asynchat.async_chat):
         self.buffer.append(data)
 
     def found_terminator(self):
-        request = ''.join(self.buffer)
+        request = ''.join(self.buffer).strip()
         reply = None
         self.buffer = []
 


### PR DESCRIPTION
@MikeHart85 stripping the newlines from the input stream makes life a lot easier when connecting via a telnet client.
