### PR TITLE
Process Adapter and Device separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ $ ./control.py simulation pause
 $ ./control.py simulation resume
 ```
 
+With these commands, the simulation is paused, while the communication with the device remains responsive. The communication channel (for example TCP stream server) would still respond to queries and commands, but they would not be processed by the device. To simulate a complete loss of connection, another pair of functions is available:
+
+```
+$ ./control.py simulation disconnect_device
+$ ./control.py simulation connect_device
+```
+
+This basically shows the opposite effect, the device simulation continues running, but the communication channel is not processed anymore and the device appears disconnected.
+
 The speed of the simulation can be adjusted as well, along with the number of cycles that are processed per second (via the `cycle_delay` parameter).
 
 ```

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -25,7 +25,7 @@ class Adapter(object):
     def __init__(self, target, bindings, arguments):
         pass
 
-    def process(self, delta, cycle_delay=0.1):
+    def process(self, cycle_delay=0.1):
         pass
 
 

--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -82,8 +82,7 @@ class StreamAdapter(Adapter):
         super(StreamAdapter, self).__init__(target, bindings, arguments)
         self._options = self._parseArguments(arguments)
 
-        self._target = target
-        self._server = StreamServer(self._options.bind_address, self.options.port, self._target, self._bindings)
+        self._server = StreamServer(self._options.bind_address, self._options.port, target, bindings)
 
     def _parseArguments(self, arguments):
         parser = ArgumentParser(description='Adapter to expose a device via TCP Stream')
@@ -92,6 +91,5 @@ class StreamAdapter(Adapter):
         parser.add_argument('-p', '--port', help='Port to listen for connections on', type=int, default=9999)
         return parser.parse_args(arguments)
 
-    def process(self, delta, cycle_delay=0.1):
+    def process(self, cycle_delay=0.1):
         asyncore.loop(cycle_delay, count=1)
-        self._target.process(delta)

--- a/plankton.py
+++ b/plankton.py
@@ -55,6 +55,7 @@ bindings = import_bindings(arguments.device, arguments.protocol if arguments.bin
 device = import_device(arguments.device, arguments.setup)
 
 simulation = Simulation(
+    device=device,
     adapter=CommunicationAdapter(device, bindings, arguments.adapter_args))
 
 simulation.cycle_delay = arguments.cycle_delay


### PR DESCRIPTION
This fixes #97.

Another step towards better separation of Adapter and Device. The `pause` function now only pauses the device, whereas the Adapter should remain responsive (the device just won't do anything as its `process`-method is not called). The new `disconnect_device`-method inhibits calling the `process`-method of the Adapter, effectively making the device appear disconnected.
