### PR TITLE
Update Dockerfile for PyZMQ and new Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dmscid/epics-pcaspy:latest
+FROM dmscid/plankton-depends:latest
 
 # Copying these separately from the rest of plankton allows the
 # pip install step to be cached until the requirements change.
@@ -10,4 +10,5 @@ RUN pip install -r plankton/requirements.txt && \
 
 COPY . /plankton
 
-ENTRYPOINT ["/init.sh", "/plankton/simulation.py"]
+ENTRYPOINT ["/init.sh", "/plankton/plankton.py"]
+


### PR DESCRIPTION
Fixes #99.

Requires https://github.com/DMSC-Instrument-Data/plankton-misc/pull/4.

This PR updates the Dockerfile to use the new `plankton.py` entrypoint (formerly `simulation.py`), and the new `plankton-depends` base image to replace `epics-pcaspy`. The new base image also includes the new PyZMQ requirement.
