### PR TITLE
Dockerfile improvements for image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ FROM dmscid/plankton-depends:latest
 # Rebuilding is faster and doesn't require an internet connection.
 COPY requirements*.txt /plankton/
 
+# Install any missing PIP requirements, clear PIP cache, and delete all compiled Python objects
 RUN pip install -r plankton/requirements.txt && \
-    pip install -r plankton/requirements-dev.txt
+    pip install -r plankton/requirements-dev.txt && \
+    rm -rf /root/.cache/pip/* && \
+    find \( -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' +
 
+# Plankton source is pulled in from current directory (note .dockerignore filters out some files)
 COPY . /plankton
 
 ENTRYPOINT ["/init.sh", "/plankton/plankton.py"]


### PR DESCRIPTION
Related to https://github.com/DMSC-Instrument-Data/plankton-misc/pull/5.

This adds a couple of lines to the Dockerfile to delete the PIP cache and any Python compiled/object files.

Along with the PR against `plankton-misc`, this drops the image size from 80+ MB to under 57 MB.
