### PR TITLE
control.py should not print None return-value

### DIFF
--- a/control.py
+++ b/control.py
@@ -69,6 +69,8 @@ parser.add_argument('-l', '--list-objects', action='store_true',
                     help='List all objects exposed by the server and exit.')
 parser.add_argument('-a', '--show-api', action='store_true',
                     help='List all properties and methods of the controlled object.')
+parser.add_argument('-n', '--print-none', action='store_true',
+                    help='Print None return value.')
 parser.add_argument('object', nargs='?', default='device', help='Object to control.')
 parser.add_argument('member', nargs='?', help='Object-member to access.')
 parser.add_argument('arguments', nargs='*',
@@ -83,4 +85,7 @@ if args.list_objects:
 elif args.show_api:
     show_api(remote, args.object)
 else:
-    print(call_method(remote, args.object, args.member, args.arguments))
+    response = call_method(remote, args.object, args.member, args.arguments)
+
+    if response is not None or args.print_none:
+        print(response)


### PR DESCRIPTION
As @OwenArnold pointed out earlier today,`control.py` is slightly confusing in that it also prints `None` when a setter is called that has no return value.

By default the script does not print `None` any more, but for debugging purposes it can be reactivated by supplying the new `-n` or `--print-none` parameter.

It's just a small fix that can be merged without conflicting with the large PR for the refactoring.
