### PR TITLE
Make device argument positional and mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ $ docker run -it [docker args] dmscid/plankton [plankton args] [-- [adapter args
 For example, to simulate a Linkam T95 **d**evice and expose it via the TCP Stream **p**rotocol:
 
 ```
-$ docker run -it dmscid/plankton -d linkam_t95 -p stream
+$ docker run -it dmscid/plankton -p stream linkam_t95
 ```
 
 To change the rate at which simulation cycles are calculated, increase or decrease the cycle delay, via the `-c` or `--cycle-delay` option. Smaller values mean more cycles per second, 0 means greates possible speed.
 
 ```
-$ docker run -it dmscid/plankton -d linkam_t95 -p stream -c 0.05
+$ docker run -it dmscid/plankton -p stream -c 0.05 linkam_t95
 ```
 
 For long running devices it might be useful to speed up the simulation using the `-e` or `--speed` parameter, which is a factor by which actual time is multiplied to determine the simulated time in each simulation cycle. To run a simulation 10 times faster:
 
 ```
-$ docker run -it dmscid/plankton -d linkam_t95 -p stream -e 10
+$ docker run -it dmscid/plankton -p stream -e 10 linkam_t95
 ```
 
 Details about parameters for the various adapters, and differences between OSes are covered in the "Adapter Specifics" sections.
@@ -150,7 +150,7 @@ $ python plankton.py [plankton args] [-- [adapter args]]
 You can then run Plankton as follows (from within the plankton directory):
 
 ```
-$ python plankton.py -d chopper -p epics
+$ python plankton.py -p epics chopper
 ```
 
 Details about parameters for the various adapters, and differences between OSes are covered in the "Adapter Specifics" sections.
@@ -165,8 +165,8 @@ The EPICS adapter takes only one optional argument:
 Arguments meant for the adapter should be separated from general Plankton arguments by a free-standing `--`. For example:
 
 ```
-$ docker run -itd dmscid/plankton -d chopper -p epics -- -p SIM1:
-$ python plankton.py -d chopper -p epics -- --prefix SIM2:
+$ docker run -itd dmscid/plankton -p epics chopper -- -p SIM1:
+$ python plankton.py -p epics chopper -- --prefix SIM2:
 ```
 
 When using the EPICS adapter within a docker container, the PV will be served on the docker0 network (172.17.0.0/16).
@@ -192,14 +192,14 @@ The TCP Stream adapter has the following optional arguments:
 Arguments meant for the adapter should be separated from general Plankton arguments by a free-standing `--`. For example:
 
 ```
-$ docker run -itd dmscid/plankton -d linkam_t95 -p stream -- -p 1234
-$ python plankton.py -d linkam_t95 -p stream -- --bind-address localhost
+$ docker run -itd dmscid/plankton -p stream linkam_t95 -- -p 1234
+$ python plankton.py -p stream linkam_t95 -- --bind-address localhost
 ```
 
 When using Plankton via Docker on Windows and OSX, the container will be running inside a virtual machine, and so the port it is listening on will be on a network inside the VM. To connect to it from outside of the VM, an additional argument must be passed to Docker to forward the port:
 
 ```
-$ docker run -it -p 1234:4321 dmscid/plankton -d linkam_t95 -p stream -- -p 4321
+$ docker run -it -p 1234:4321 dmscid/plankton -p stream linkam_t95 -- -p 4321
 $ telnet 192.168.99.100 1234
 ```
 
@@ -212,7 +212,7 @@ This `-p` argument links port 4321 on the container to port 1234 on the VM netwo
 Besides the device specific protocols, the device can be made accessible from the outside via JSON-RPC over ZMQ. This can be achieved by passing the `-r` option with a `host:port` string to the simulation:
 
 ```
-$ python plankton.py -r 127.0.0.1:10000 -d chopper -- -p SIM:
+$ python plankton.py -r 127.0.0.1:10000 chopper -- -p SIM:
 ```
 
 Now the device can be controlled via the `control.py`-script in a different terminal window. The service can be queried to show the available objects using the `-l` or `--list-objects` flag:

--- a/plankton.py
+++ b/plankton.py
@@ -28,8 +28,7 @@ from adapters import import_adapter, get_available_adapters, Adapter
 
 parser = argparse.ArgumentParser(
     description='Run a simulated device and expose it via a specified communication protocol.')
-parser.add_argument('-d', '--device', help='Name of the device to simulate.', default='chopper',
-                    choices=get_available_submodules('devices'))
+
 parser.add_argument('-r', '--rpc-host', help='HOST:PORT format string for exposing the device via JSON-RPC over ZMQ.')
 parser.add_argument('-s', '--setup', help='Name of the setup to load.', default=None)
 parser.add_argument('-l', '--list-protocols', help='List available protocols for selected device.', action='store_true')
@@ -40,6 +39,8 @@ parser.add_argument('-c', '--cycle-delay',
 parser.add_argument('-e', '--speed', type=float, default=1.0,
                     help='Simulation speed. The actually elapsed time '
                          'between two cycles is multiplied with this speed to determine the simulated time.')
+parser.add_argument('device', help='Name of the device to simulate.', default='chopper',
+                    choices=get_available_submodules('devices'))
 parser.add_argument('adapter_args', nargs='*', help='Arguments for the adapter.')
 
 arguments = parser.parse_args()

--- a/plankton.py
+++ b/plankton.py
@@ -39,7 +39,7 @@ parser.add_argument('-c', '--cycle-delay',
 parser.add_argument('-e', '--speed', type=float, default=1.0,
                     help='Simulation speed. The actually elapsed time '
                          'between two cycles is multiplied with this speed to determine the simulated time.')
-parser.add_argument('device', help='Name of the device to simulate.', default='chopper',
+parser.add_argument('device', help='Mandatory name of the device to simulate.', default='chopper',
                     choices=get_available_submodules('devices'))
 parser.add_argument('adapter_args', nargs='*', help='Arguments for the adapter.')
 


### PR DESCRIPTION
This fixes #111.

For a long time we had chopper as the default device, but that seems a bit arbitrary now that the framework is specifically targeting devices in general.

The device argument is now mandatory and thus converted into a positional argument. The `-d`-switch has been removed.

**Note: This is based off branch `fix_tests`, please merge this afterwards.**
