### PR TITLE
Make control.py easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,16 +215,16 @@ Besides the device specific protocols, the device can be made accessible from th
 $ python plankton.py -r 127.0.0.1:10000 -d chopper -- -p SIM:
 ```
 
-Now the device can be controlled via the `control.py`-script in a different terminal window. The service can be queried to show the available objects using the `-l` or `--list-objects` flag:
+Now the device can be controlled via the `control.py`-script in a different terminal window. The service can be queried to show the available objects by not supplying an object name:
 
 ```
-$ python control.py -r 127.0.0.1:10000 --list-objects
+$ python control.py -r 127.0.0.1:10000
 ```
 
-The `-r` (or `--rpc-host`) option defaults to the value shown here, so it will be omitted in the following examples. To get information on the API of an object, the `-a` or `--show-api` option can be used in conjunction with a device name obtained from the previous command:
+The `-r` (or `--rpc-host`) option defaults to the value shown here, so it will be omitted in the following examples. To get information on the API of an object, supplying an object name without a property or method will list the object's API:
 
 ```
-$ python control.py -a device
+$ python control.py device
 ```
 
 This will output a list of properties and methods which is available for remote access. This may not comprise the full interface of the object depending on the server side configuration. Obtaining the value of a property is done like this:

--- a/control.py
+++ b/control.py
@@ -65,14 +65,11 @@ parser = argparse.ArgumentParser(
     description='A client to manipulate the simulated device remotely through a separate channel. The simulation must be started with the --rpc-host option.')
 parser.add_argument('-r', '--rpc-host', default='127.0.0.1:10000',
                     help='HOST:PORT string specifying control server to connect to.')
-parser.add_argument('-l', '--list-objects', action='store_true',
-                    help='List all objects exposed by the server and exit.')
-parser.add_argument('-a', '--show-api', action='store_true',
-                    help='List all properties and methods of the controlled object.')
 parser.add_argument('-n', '--print-none', action='store_true',
                     help='Print None return value.')
-parser.add_argument('object', nargs='?', default='device', help='Object to control.')
-parser.add_argument('member', nargs='?', help='Object-member to access.')
+parser.add_argument('object', nargs='?', default=None, help='Object to control. If left out, all objects are listed.')
+parser.add_argument('member', nargs='?', default=None,
+                    help='Object-member to access. If omitted, API of the object is listed.')
 parser.add_argument('arguments', nargs='*',
                     help='Arguments to method call. For setting a property, supply the property value. ')
 
@@ -80,12 +77,13 @@ args = parser.parse_args()
 
 remote = ControlClient(*args.rpc_host.split(':')).get_object_collection()
 
-if args.list_objects:
+if not args.object:
     list_objects(remote)
-elif args.show_api:
-    show_api(remote, args.object)
 else:
-    response = call_method(remote, args.object, args.member, args.arguments)
+    if not args.member:
+        show_api(remote, args.object)
+    else:
+        response = call_method(remote, args.object, args.member, args.arguments)
 
-    if response is not None or args.print_none:
-        print(response)
+        if response is not None or args.print_none:
+            print(response)


### PR DESCRIPTION
This fixes #112.

The two options to list all objects and to list an object's API are removed. Instead it is now enough to supply no object argument to get all objects and no member argument to get all members.

**Note: This is branched off `fix_tests`, please merge this branch afterwards.**
