### PR TITLE
Issue in literal processing

### DIFF
--- a/control.py
+++ b/control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import ast
 import argparse
 from core.control_client import ControlClient
 
@@ -37,12 +37,9 @@ def show_api(remote, object_name):
 
 def convert_type(value):
     try:
-        return int(value)
+        return ast.literal_eval(value)
     except ValueError:
-        try:
-            return float(value)
-        except ValueError:
-            return value
+        return value
 
 
 def call_method(remote, object_name, method, arguments):


### PR DESCRIPTION
This took me a little while to track down. But if you have a device that has a bool, and you try to set it via `control.py`, the convert_type wrapper does not change the literal from a unicode string to a bool and it is then difficult to find out what the problem is in your `Device`.
