### PR TITLE
Remove regex_flags argument from Stream Cmd

### DIFF
--- a/adapters/stream.py
+++ b/adapters/stream.py
@@ -87,7 +87,7 @@ class StreamServer(asyncore.dispatcher):
 
 
 class Cmd(object):
-    def __init__(self, target_method, regex, regex_flags=0, argument_mappings=None,
+    def __init__(self, target_method, regex, argument_mappings=None,
                  return_mapping=lambda x: None if x is None else str(x)):
         """
         This is a small helper class that makes it easy to define commands that are parsed
@@ -107,12 +107,11 @@ class Cmd(object):
 
         :param target_method: Method to be called when regex matches.
         :param regex: Regex to match for method call.
-        :param regex_flags: Flags to pass ot re.compile, default is 0.
         :param argument_mappings: Iterable with mapping functions from string to some type.
         :param return_mapping: Mapping function for return value of method.
         """
         self.method = target_method
-        self.pattern = re.compile(b(regex), regex_flags)
+        self.pattern = re.compile(b(regex))
 
         if argument_mappings is not None and (self.pattern.groups != len(argument_mappings)):
             raise RuntimeError(


### PR DESCRIPTION
Consider this PR a suggestion.

The regex flags can be set directly in the regex using the following syntax:

> (?iLmsux)
>    (One or more letters from the set 'i', 'L', 'm', 's', 'u', 'x'.) The group matches the empty string; the letters set the corresponding flags: re.I (ignore case), re.L (locale dependent), re.M (multi-line), re.S (dot matches all), re.U (Unicode dependent), and re.X (verbose), for the entire regular expression. (The flags are described in Module Contents.) This is useful if you wish to include the flags as part of the regular expression, instead of passing a flag argument to the re.compile() function.
>    Note that the (?x) flag changes how the expression is parsed. It should be used first in the expression string, or after one or more whitespace characters. If there are non-whitespace characters before the flag, the results are undefined.

This makes exposing regex_flags as an argument a bit redundant. Removing it makes the semantics of creating a Cmd a bit cleaner. You can just do, for example:

``` python
Cmd('set_rate', '^R1([0-9]+)$', (int,))
```

Without having to name the argument_mappings parameter to get around the regex_flags parameter.
