### PR TITLE
Remove Context class and fix naming issues

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,5 +17,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from .statemachine import StateMachine, State, Transition, Context
+from .statemachine import StateMachine, State, Transition
 from .processor import CanProcess, CanProcessComposite

--- a/core/processor.py
+++ b/core/processor.py
@@ -77,9 +77,9 @@ class CanProcessComposite(CanProcess):
 
     def add_processor(self, other):
         if isinstance(other, CanProcess):
-            self._appendProcessor(other)
+            self._append_processor(other)
 
-    def _appendProcessor(self, processor):
+    def _append_processor(self, processor):
         self._processors.append(processor)
 
     def doProcess(self, dt):

--- a/core/processor.py
+++ b/core/processor.py
@@ -59,7 +59,7 @@ class CanProcessComposite(CanProcess):
     Items can be added to the composite like this:
 
         composite = CanProcessComposite()
-        composite.addProcessor(item_that_implements_CanProcess)
+        composite.add_processor(item_that_implements_CanProcess)
 
     The process-method calls the process-method of each contained
     item. Specific things that have to be done before or after the
@@ -73,9 +73,9 @@ class CanProcessComposite(CanProcess):
         self._processors = []
 
         for item in iterable:
-            self.addProcessor(item)
+            self.add_processor(item)
 
-    def addProcessor(self, other):
+    def add_processor(self, other):
         if isinstance(other, CanProcess):
             self._appendProcessor(other)
 

--- a/core/statemachine.py
+++ b/core/statemachine.py
@@ -28,41 +28,6 @@ class StateMachineException(Exception):
     pass
 
 
-# Derived from http://stackoverflow.com/a/3603824
-class Context(object):
-    """
-    Device context.
-
-    Represents the internal memory of the device. This is used to share device
-    state (as opposed to state machine state) between a device class, its
-    states' implementations and their transitions.
-
-    Use by inheriting this class and overriding `initialize` to set any variables
-    that should be part of the device context.
-
-    The freeze mechanism automatically prevents this class from being extended
-    outside of `initialize`. This is to prevent bugs cause by typos and the
-    like, raising an Exception instead to draw attention to any potentially
-    misspelled attributes.
-    """
-    __is_frozen = False
-
-    def __init__(self):
-        self.initialize()
-        self._freeze()
-
-    def initialize(self):
-        pass
-
-    def _freeze(self):
-        self.__is_frozen = True
-
-    def __setattr__(self, key, value):
-        if self.__is_frozen and not hasattr(self, key):
-            raise StateMachineException("Class {} does not have attribute: '{}'".format(self.__class__.__name__, key))
-        object.__setattr__(self, key, value)
-
-
 class HasContext(object):
     """
     Mixin to provide a Context.
@@ -78,7 +43,7 @@ class HasContext(object):
         super(HasContext, self).__init__()
         self._context = None
 
-    def setContext(self, new_context):
+    def set_context(self, new_context):
         self._context = new_context
 
 
@@ -208,7 +173,7 @@ class StateMachine(CanProcess):
         # Allow user to explicitly specify state handlers
         for state_name, handlers in iteritems(cfg.get('states', {})):
             if isinstance(handlers, HasContext):
-                handlers.setContext(context)
+                handlers.set_context(context)
 
             try:
                 if isinstance(handlers, State):
@@ -233,7 +198,7 @@ class StateMachine(CanProcess):
                 self._set_handlers(to_state)
 
             if isinstance(check_func, HasContext):
-                check_func.setContext(context)
+                check_func.set_context(context)
 
             # Set up the transition
             self._set_transition(from_state, to_state, check_func)

--- a/devices/__init__.py
+++ b/devices/__init__.py
@@ -95,7 +95,7 @@ class StateMachineDevice(CanProcessComposite):
             'transitions': self._get_final_transition_handlers(override_transitions)
         }, context=self)
 
-        self.addProcessor(self._csm)
+        self.add_processor(self._csm)
 
     def _get_state_handlers(self):
         """

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -80,7 +80,7 @@ class TestCanProcessComposite(unittest.TestCase):
         composite = CanProcessComposite()
 
         with patch.object(composite, '_appendProcessor') as appendProcessorMock:
-            composite.addProcessor(CanProcess())
+            composite.add_processor(CanProcess())
 
         self.assertEquals(appendProcessorMock.call_count, 1)
 
@@ -88,7 +88,7 @@ class TestCanProcessComposite(unittest.TestCase):
         composite = CanProcessComposite()
 
         with patch.object(composite, '_appendProcessor') as appendProcessorMock:
-            composite.addProcessor(None)
+            composite.add_processor(None)
 
         appendProcessorMock.assert_not_called()
 

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -79,7 +79,7 @@ class TestCanProcessComposite(unittest.TestCase):
     def test_addProcessor_if_argument_CanProcess(self):
         composite = CanProcessComposite()
 
-        with patch.object(composite, '_appendProcessor') as appendProcessorMock:
+        with patch.object(composite, '_append_processor') as appendProcessorMock:
             composite.add_processor(CanProcess())
 
         self.assertEquals(appendProcessorMock.call_count, 1)
@@ -87,7 +87,7 @@ class TestCanProcessComposite(unittest.TestCase):
     def test_addProcessor_if_argument_not_CanProcess(self):
         composite = CanProcessComposite()
 
-        with patch.object(composite, '_appendProcessor') as appendProcessorMock:
+        with patch.object(composite, '_append_processor') as appendProcessorMock:
             composite.add_processor(None)
 
         appendProcessorMock.assert_not_called()

--- a/test/test_StateMachine.py
+++ b/test/test_StateMachine.py
@@ -20,7 +20,7 @@
 import unittest
 from mock import Mock, patch
 
-from core.statemachine import StateMachine, State, Transition, Context
+from core.statemachine import StateMachine, State, Transition
 from core.statemachine import StateMachineException
 
 
@@ -93,7 +93,7 @@ class TestStateMachine(unittest.TestCase):
 
     def test_Transition_receives_Context(self):
         transition = Transition()
-        context = Context()
+        context = object()
         sm = StateMachine({
             'initial': 'foo',
             'transitions': {
@@ -214,7 +214,7 @@ class TestStateMachine(unittest.TestCase):
 
     def test_State_receives_Context(self):
         state = State()
-        context = Context()
+        context = object()
         sm = StateMachine({
             'initial': 'foo',
             'states': {


### PR DESCRIPTION
This fixes #121.

The `Context`-class was no longer required and is consequently removed. The `setContext`-method of `HasContext` was renamed to fit the underscore naming.

Additionally some small conflicts with that scheme are fixed.
