### PR TITLE
Added basic flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-complexity = 12
+exclude = .git, docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ services:
 python:
   - "2.7"
   - "3.5"
+
 install:
   - pip install -r requirements-dev.txt
   - pip install coveralls
+  - pip install flake8
+
 script:
+  - flake8 .
   - nosetests -w test --with-coverage --cover-package=core,devices
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ python:
 install:
   - pip install -r requirements-dev.txt
   - pip install coveralls
-  - pip install flake8
 
 script:
   - flake8 .

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -36,26 +36,29 @@ class Adapter(object):
 
 def is_adapter(obj):
     try:
-        return issubclass(obj, Adapter) and not obj.__module__.startswith('adapters')
+        return issubclass(obj, Adapter) \
+               and not obj.__module__.startswith('adapters')
     except TypeError:
         return False
 
 
 def get_available_adapters(device_name, device_package):
     """
-    This helper function returns a dictionary with name/type pairs. It imports the module
-    device_package.device_name.adapters and puts those members of the module that inherit
-    from Adapter into the dictionary.
+    This helper function returns a dictionary with name/type pairs.
+    It imports the module device_package.device_name.adapters and puts
+    those members of the module that inherit from Adapter into the dictionary.
 
     :param device_name: Device name for which to get the adapters.
     :param device_package: Name of the package where devices are defined.
-    :return: Dictionary of name/type pairs for available adapters for that device.
+    :return: Dictionary of name/type for available adapters for the device.
     """
     adapters = dict()
 
     try:
-        adapter_module = importlib.import_module('{}.{}.{}'.format(device_package, device_name, 'interfaces'))
-        module_members = {member: getattr(adapter_module, member) for member in dir(adapter_module)}
+        adapter_module = importlib.import_module(
+            '{}.{}.{}'.format(device_package, device_name, 'interfaces'))
+        module_members = {member: getattr(adapter_module, member)
+                          for member in dir(adapter_module)}
 
         for name, member in module_members.items():
             if is_adapter(member):
@@ -63,7 +66,8 @@ def get_available_adapters(device_name, device_package):
     except ImportError:
         pass
 
-    device_module = importlib.import_module('{}.{}'.format(device_package, device_name))
+    device_module = importlib.import_module(
+        '{}.{}'.format(device_package, device_name))
 
     for member in dir(device_module):
         member_object = getattr(device_module, member)
@@ -76,15 +80,16 @@ def get_available_adapters(device_name, device_package):
 
 def import_adapter(device_name, protocol_name, device_package='devices'):
     """
-    This function tries to import an adapter for the given device that implements
-    the requested protocol. If no adapter for that protocol exists, an exception
-    is raised. If protocol name is None, the function returns an
-    unspecified adapter. If no adapters are found at all, an error is raised.
+    This function tries to import an adapter for the given device
+    that implements the requested protocol. If no adapter for that protocol
+    exists, an exception is raised. If protocol name is None, the function
+    returns an unspecified adapter. If no adapters are found at all,
+    an error is raised.
 
     :param device_name: Name of device for which an adapter is requested.
     :param protocol_name: Requested protocol implemented by adapter.
     :param device_package: Name of the package where devices are defined.
-    :return: Adapter class that implements requested protocol for the specified device.
+    :return: Adapter class that implements requested protocol for the device.
     """
     available_adapters = get_available_adapters(device_name, device_package)
 
@@ -96,7 +101,8 @@ def import_adapter(device_name, protocol_name, device_package='devices'):
             return adapter
 
     raise RuntimeError(
-        'No suitable adapter found for device \'{}\' and protocol \'{}\'.'.format(device_name, protocol_name))
+        'No suitable adapter found for device \'{}\' '
+        'and protocol \'{}\'.'.format(device_name, protocol_name))
 
 
 class ForwardProperty(object):

--- a/adapters/epics.py
+++ b/adapters/epics.py
@@ -30,15 +30,17 @@ from datetime import datetime
 
 
 class PV(object):
-    def __init__(self, target_property, poll_interval=1.0, read_only=False, **kwargs):
+    def __init__(self, target_property, poll_interval=1.0,
+                 read_only=False, **kwargs):
         """
-        The PV-class is used to declare the EPICS-interface exposed by a sub-class of
-        EpicsAdapter. The target_property argument specifies which property of the adapter
-        the PV maps to. If the PV should be read only, this needs to be specified via
-        the corresponding parameter. The information about the poll interval is used
-        py EpicsAdapter to update the PV in regular intervals. All other named arguments
-        are forwarded to the pcaspy server's `pvdb`, so it's possible to pass on
-        limits, types, enum-values and so on.
+        The PV-class is used to declare the EPICS-interface exposed
+        by a sub-class of EpicsAdapter. The target_property argument
+        specifies which property of the adapter the PV maps to. If the PV
+        should be read only, this needs to be specified via the corresponding
+        parameter. The information about the poll interval is used
+        py EpicsAdapter to update the PV in regular intervals. All other
+        named arguments are forwarded to the pcaspy server's `pvdb`, so it's
+        possible to pass on limits, types, enum-values and so on.
 
         :param target_property: Property of the adapter to expose.
         :param poll_interval: Update interval of the PV.
@@ -77,7 +79,8 @@ class PropertyExposingDriver(Driver):
             self._timers[pv] += dt
             if self._timers[pv] >= pv_object.poll_interval:
                 try:
-                    self.setParam(pv, getattr(self._target, pv_object.property))
+                    self.setParam(pv, getattr(self._target,
+                                              pv_object.property))
                     self._timers[pv] = 0.0
                 except (AttributeError, TypeError):
                     pass
@@ -87,14 +90,14 @@ class PropertyExposingDriver(Driver):
 
 class EpicsAdapter(Adapter):
     """
-    Inheriting from this class provides an EPICS-interface to a device, powered by
-    the pcaspy-module. In the simplest case all that is required is to inherit
-    from this class and override the `pvs`-member. It should be a dictionary
-    that contains PV-names (without prefix) as keys and instances of PV as
-    values.
+    Inheriting from this class provides an EPICS-interface to a device,
+    powered by the pcaspy-module. In the simplest case all that is required
+    is to inherit from this class and override the `pvs`-member. It should
+    be a dictionary that contains PV-names (without prefix) as keys and
+    instances of PV as values.
 
-    For a simple device with two properties, speed and position, the first of which
-    should be read-only, it's enough to define the following:
+    For a simple device with two properties, speed and position, the first
+    of which should be read-only, it's enough to define the following:
 
         class SimpleDeviceEpicsAdapter(EpicsAdapter):
             pvs = {
@@ -122,19 +125,20 @@ class EpicsAdapter(Adapter):
                 if value == 1:
                     self._device.halt()
 
-    Even though the device does _not_ have a property called 'stop' (but a method called 'halt'),
-    issuing the command
+    Even though the device does _not_ have a property called 'stop'
+    (but a method called 'halt'), issuing the command
 
         caput STOP 1
 
-    will achieve the desired behavior, because EpicsAdapter merges the properties
-    of the device into SimpleDeviceEpicsAdapter itself, so that it is does not
-    matter whether the specified property in PV exists in the device or the adapter.
+    will achieve the desired behavior, because EpicsAdapter merges the
+    properties of the device into SimpleDeviceEpicsAdapter itself, so that
+    it is does not matter whether the specified property in PV exists
+    in the device or the adapter.
 
     The intention of this design is to keep device classes small and free of
     protocol specific stuff, such as in the case above where stopping a device
-    via EPICS might involve writing a value to a PV, whereas other protocols may
-    offer an RPC-way of achieving the same thing.
+    via EPICS might involve writing a value to a PV, whereas other protocols
+    may offer an RPC-way of achieving the same thing.
     """
     protocol = 'epics'
     pvs = None
@@ -162,22 +166,25 @@ class EpicsAdapter(Adapter):
         for pv in pvs:
             prop = pv.property
 
-            if not prop in dir(self):
-                if not prop in dir(self._device):
-                    raise AttributeError('Can not find property \'' + prop + '\' in device or interface.')
+            if prop not in dir(self):
+                if prop not in dir(self._device):
+                    raise AttributeError(
+                        'Can not find property \'' + prop
+                        + '\' in device or interface.')
                 setattr(type(self), prop, ForwardProperty('_device', prop))
 
     def _parseArguments(self, arguments):
-        parser = ArgumentParser(description="Adapter to expose a device via EPICS")
-        parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
+        parser = ArgumentParser(
+            description="Adapter to expose a device via EPICS")
+        parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs',
+                            default='')
         return parser.parse_args(arguments)
 
     def handle(self, cycle_delay=0.1):
-        # pcaspy's process() is weird. Docs claim argument is "processing time" in seconds.
-        # But this is not at all consistent with the calculated delta.
-        # Having "watch caget" running has a huge effect too (runs faster when watching!)
-        # Additionally, if you don't call it every ~0.05s or less, PVs stop working. Annoying.
-        # Set it to 0.0 for maximum cycle speed.
+        # pcaspy's process() is weird. Docs claim argument is "processing time"
+        # in seconds. But this is not at all consistent with the calculated
+        # delta. Having "watch caget" running has a huge effect too
+        # (runs faster when watching). Set it to 0.0 for maximum cycle speed.
         self._server.process(cycle_delay)
         self._driver.process_pv_updates(seconds_since(self._last_update))
         self._last_update = datetime.now()

--- a/control.py
+++ b/control.py
@@ -10,9 +10,10 @@ def list_objects(remote):
 
 
 def show_api(remote, object_name):
-    if not object_name in remote.keys():
+    if object_name not in remote.keys():
         raise RuntimeError(
-            'Object \'{}\' is not exposed by remote. Use -l to get a list of objects.'.format(object_name))
+            'Object \'{}\' is not exposed by remote. '
+            'Use -l to get a list of objects.'.format(object_name))
 
     obj = remote[object_name]
 
@@ -44,7 +45,8 @@ def convert_type(value):
 
 def call_method(remote, object_name, method, arguments):
     if not method:
-        raise RuntimeError('Missing object member. Use -a to get a list of members.')
+        raise RuntimeError('Missing object member. '
+                           'Use -a to get a list of members.')
 
     attr = getattr(remote[object_name], method)
     args = [convert_type(arg) for arg in arguments]
@@ -59,16 +61,23 @@ def call_method(remote, object_name, method, arguments):
 
 
 parser = argparse.ArgumentParser(
-    description='A client to manipulate the simulated device remotely through a separate channel. The simulation must be started with the --rpc-host option.')
+    description='A client to manipulate the simulated device remotely through'
+                ' a separate channel. The simulation must be started '
+                'with the --rpc-host option.')
 parser.add_argument('-r', '--rpc-host', default='127.0.0.1:10000',
-                    help='HOST:PORT string specifying control server to connect to.')
+                    help='HOST:PORT string specifying control server '
+                         'to connect to.')
 parser.add_argument('-n', '--print-none', action='store_true',
                     help='Print None return value.')
-parser.add_argument('object', nargs='?', default=None, help='Object to control. If left out, all objects are listed.')
+parser.add_argument('object', nargs='?', default=None,
+                    help='Object to control. '
+                         'If left out, all objects are listed.')
 parser.add_argument('member', nargs='?', default=None,
-                    help='Object-member to access. If omitted, API of the object is listed.')
+                    help='Object-member to access. If omitted, '
+                         'API of the object is listed.')
 parser.add_argument('arguments', nargs='*',
-                    help='Arguments to method call. For setting a property, supply the property value. ')
+                    help='Arguments to method call. For setting a property, '
+                         'supply the property value. ')
 
 args = parser.parse_args()
 
@@ -80,7 +89,8 @@ else:
     if not args.member:
         show_api(remote, args.object)
     else:
-        response = call_method(remote, args.object, args.member, args.arguments)
+        response = call_method(remote, args.object, args.member,
+                               args.arguments)
 
         if response is not None or args.print_none:
             print(response)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -23,6 +23,6 @@ from .control_server import ControlServer, ExposedObject, \
     ExposedObjectCollection
 from .control_client import ControlClient
 
-__all__ = [StateMachine, State, Transition, HasContext, CanProcess,
-           CanProcessComposite, ControlServer, ExposedObject,
-           ExposedObjectCollection, ControlClient]
+__all__ = ['StateMachine', 'State', 'Transition', 'HasContext', 'CanProcess',
+           'CanProcessComposite', 'ControlServer', 'ExposedObject',
+           'ExposedObjectCollection', 'ControlClient']

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,5 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from .statemachine import StateMachine, State, Transition
+from .statemachine import StateMachine, State, Transition, HasContext
 from .processor import CanProcess, CanProcessComposite
+from .control_server import ControlServer, ExposedObject, \
+    ExposedObjectCollection
+from .control_client import ControlClient
+
+__all__ = [StateMachine, State, Transition, HasContext, CanProcess,
+           CanProcessComposite, ControlServer, ExposedObject,
+           ExposedObjectCollection, ControlClient]

--- a/core/control_client.py
+++ b/core/control_client.py
@@ -32,14 +32,15 @@ class RemoteException(Exception):
         """
         This exception type replaces exceptions that are raised on the server,
         but unknown (i.e. not in the exceptions-module) on the client side.
-        To retain as much information as possible, the exception type on the server and
-        the message are stored.
+        To retain as much information as possible, the exception type on the
+        server and the message are stored.
 
         :param type: Type of the exception on the server side.
         :param message: Exception message on the server side.
         """
         super(RemoteException, self).__init__(
-            'Exception on server side of type \'{}\': \'{}\''.format(type, message))
+            'Exception on server side of '
+            'type \'{}\': \'{}\''.format(type, message))
 
         self.server_side_type = type
         self.server_side_message = message
@@ -74,10 +75,11 @@ class ControlClient(object):
     def json_rpc(self, method, *args):
         """
         This method takes a ZMQ REQ-socket and submits a JSON-object containing
-        the RPC (JSON-RPC 2.0 format) to the supplied method with the supplied arguments.
-        Then it waits for a reply from the server and blocks until it has received
-        a JSON-response. The method returns the response and the id it used to tag
-        the original request, which is a random UUID (uuid.uuid4).
+        the RPC (JSON-RPC 2.0 format) to the supplied method with the supplied
+        arguments. Then it waits for a reply from the server and blocks until
+        it has received a JSON-response. The method returns the response and
+        the id it used to tag the original request,
+        which is a random UUID (uuid.uuid4).
 
         :param method: Method to call on remote.
         :param args: Arguments to method call.
@@ -96,7 +98,7 @@ class ControlClient(object):
     def get_object(self, object_name=''):
         api, request_id = self.json_rpc(object_name + ':api')
 
-        if not 'result' in api or api['id'] != request_id:
+        if 'result' not in api or api['id'] != request_id:
             raise ProtocolException('Failed to retrieve API of remote object.')
 
         object_type = type(str(api['result']['class']), (ObjectProxy,), {})
@@ -107,13 +109,15 @@ class ControlClient(object):
 
     def get_object_collection(self, object_name=''):
         """
-        If the remote end exposes a collection of objects under the supplied object name (empty
-        for top level), this method returns a dictionary of these objects stored under their
-        names on the server.
+        If the remote end exposes a collection of objects under the supplied
+        object name (empty for top level), this method returns a dictionary
+        of these objects stored under their names on the server.
 
-        This function performs n + 1 calls to the server, where n is the number of objects.
+        This function performs n + 1 calls to the server, where n is
+        the number of objects.
 
-        :param object_name: Object name on the server. This is required if the object collection is not the top level object.
+        :param object_name: Object name on the server. This is required if
+        the object collection is not the top level object.
         """
 
         object_names = self.get_object(object_name).get_objects()
@@ -124,25 +128,27 @@ class ControlClient(object):
 class ObjectProxy(object):
     def __init__(self, connection, members, prefix=''):
         """
-        This class serves as a base class for dynamically created classes on the
-        client side that represent server-side objects. Upon initialization,
-        this class takes the supplied methods and installs appropriate proxy methods
-        or properties into the object and class respectively. Because of that
-        class manipulation, this class must never be used directly.
-        Instead, it should be used as a base-class for dynamically created types
-        that mirror types on the server, like this:
+        This class serves as a base class for dynamically created classes on
+        the client side that represent server-side objects.
+        Upon initialization, this class takes the supplied methods and installs
+        appropriate proxy methods or properties into the object and class
+        respectively. Because of that class manipulation, this class must never
+        be used directly. Instead, it should be used as a base-class for
+        dynamically created types that mirror types on the server, like this:
 
-            proxy = type('SomeClassName', (ObjectProxy, ), {})(connection, methods, prefix)
+            proxy = type('SomeClassName', (ObjectProxy, ), {})(
+                        connection, methods, prefix)
 
         There is however, the class ControlClient, which automates all that
         and provides objects that are ready to use.
 
-        Exceptions on the server are propagated to the client. If the exception is not part
-        of the exceptions-module (builtins for Python 3), a RemoteException is raised instead
-        which contains information about the server side exception.
+        Exceptions on the server are propagated to the client. If the exception
+        is not part of the exceptions-module (builtins for Python 3),
+        a RemoteException is raised instead which contains information about
+        the server side exception.
 
-        All RPC method names are prefixed with the supplied prefix, which is usually the
-        object name on the server plus a dot.
+        All RPC method names are prefixed with the supplied prefix, which is
+        usually the object name on the server plus a dot.
 
         :param connection: ControlClient-object for remote calls.
         :param members: List of strings to generate methods and properties.
@@ -156,9 +162,10 @@ class ObjectProxy(object):
 
     def _make_request(self, method, *args):
         """
-        This method performs a JSON-RPC request via the object's ZMQ socket. If successful,
-        the result is returned, otherwise exceptions are raised. Server side exceptions are
-        raised using the same type as on the server if they are part of the exceptions-module.
+        This method performs a JSON-RPC request via the object's ZMQ socket.
+        If successful, the result is returned, otherwise exceptions are raised.
+        Server side exceptions are raised using the same type as on the server
+        if they are part of the exceptions-module.
         Otherwise, a RemoteException is raised.
 
         :param method: Method of the object to call on the remote.
@@ -191,8 +198,9 @@ class ObjectProxy(object):
                 setattr(self, member, self._create_method_proxy(member))
 
         for prop in self._properties:
-            setattr(type(self), prop, property(self._create_getter_proxy(prop),
-                                               self._create_setter_proxy(prop)))
+            setattr(type(self),
+                    prop, property(self._create_getter_proxy(prop),
+                                   self._create_setter_proxy(prop)))
 
     def _create_getter_proxy(self, property_name):
         def getter(obj):

--- a/core/control_server.py
+++ b/core/control_server.py
@@ -25,28 +25,34 @@ from jsonrpc import JSONRPCResponseManager
 class ExposedObject(object):
     def __init__(self, object, members=None, exclude=None):
         """
-        ExposedObject is a class that makes it easy to expose an object via the JSONRPCResponseManager
-        from the json-rpc package, where it can serve as a dispatcher. For this purpose it exposes
-        a read-only dict-like interface.
+        ExposedObject is a class that makes it easy to expose an object via
+        the JSONRPCResponseManager from the json-rpc package, where it can
+        serve as a dispatcher. For this purpose it exposes a read-only
+        dict-like interface.
 
-        The basic problem solved by this wrapper is that plain data members of an object are not
-        really captured well by the RPC-approach, where a client performs function calls on a
-        remote machine and gets the result back.
+        The basic problem solved by this wrapper is that plain data members of
+        an object are not really captured well by the RPC-approach, where a
+        client performs function calls on a remote machine and
+        gets the result back.
 
-        The supplied object is inspected using dir(object) and all entries that do not start
-        with a _ are exposed in a way that depends on whether the corresponding member
-        is a method or a property (either in the Python-sense or the general OO-sense). Methods
-        are stored directly, and stored in an internal dict where the method name is the key and the
-        callable method object is the value. For properties, a getter- and a setter function
-        are generated, which are then stored in the same dict. The names of these methods for
-        a property called 'a' are 'a:get' and 'a:set'. The separator has been chosen to be
-        colon because it can't be part of a valid Python identifier.
+        The supplied object is inspected using dir(object) and all entries
+        that do not start with a _ are exposed in a way that depends on whether
+        the corresponding member is a method or a property
+        (either in the Python-sense or the general OO-sense). Methods are
+        stored directly, and stored in an internal dict where the method name
+        is the key and the callable method object is the value.
+        For properties, a getter- and a setter function are generated,
+        which are then stored in the same dict. The names of these methods for
+        a property called 'a' are 'a:get' and 'a:set'. The separator has been
+        chosen to be colon because it can't be part of a valid Python
+        identifier.
 
-        If the second argument is not empty, it is interpreted to be the list of members
-        to expose and only those are actually exposed. This can be used to explicitly expose
-        members of an object that start with an underscore. If all but one or two members
-        should be exposed, it's also possible to use the exclude-argument to explicitly
-        exclude a few members. Both parameters can be used in combination, the exclude-list
+        If the second argument is not empty, it is interpreted to be the list
+        of members to expose and only those are actually exposed. This can be
+        used to explicitly expose members of an object that start with an
+        underscore. If all but one or two members should be exposed, it's also
+        possible to use the exclude-argument to explicitly exclude a few
+        members. Both parameters can be used in combination, the exclude-list
         takes precedence.
 
         :param object: The object to expose.
@@ -60,17 +66,19 @@ class ExposedObject(object):
 
         self._add_function(':api', self.get_api)
 
-        exposed_members = members if members else [prop for prop in dir(self._object) if not prop.startswith('_')]
+        exposed_members = members if members else [prop for prop in
+                                                   dir(self._object) if
+                                                   not prop.startswith('_')]
 
         for method in exposed_members:
-            if not exclude or not method in exclude:
+            if not exclude or method not in exclude:
                 self._add_member_wrappers(method)
 
     def _add_member_wrappers(self, member):
         """
-        This method probes the supplied member of the wrapped object and inserts an appropriate
-        entry into the internal method map. Getters and setters for properties get a suffix
-        ':get' and ':set' respectively.
+        This method probes the supplied member of the wrapped object and
+        inserts an appropriate entry into the internal method map. Getters
+        and setters for properties get a suffix ':get' and ':set' respectively.
 
         :param member: The member of the wrapped object to expose
         """
@@ -79,7 +87,8 @@ class ExposedObject(object):
         if callable(method_object):
             self._add_function(member, method_object)
         else:
-            self._add_function('{}:get'.format(member), lambda: getattr(self._object, member))
+            self._add_function('{}:get'.format(member),
+                               lambda: getattr(self._object, member))
 
             def setter(arg):
                 return setattr(self._object, member, arg)
@@ -88,12 +97,14 @@ class ExposedObject(object):
 
     def get_api(self):
         """
-        This method returns the class name and a list of exposed methods. It is exposed to RPC-clients by an
-        instance of ExposedObjectCollection.
+        This method returns the class name and a list of exposed methods.
+        It is exposed to RPC-clients by an instance of ExposedObjectCollection.
 
-        :return: A dictionary describing the exposed API (consisting of a class name and methods).
+        :return: A dictionary describing the exposed API (consisting of a class
+        name and methods).
         """
-        return {'class': type(self._object).__name__, 'methods': list(self._function_map.keys())}
+        return {'class': type(self._object).__name__,
+                'methods': list(self._function_map.keys())}
 
     def __getitem__(self, item):
         return self._function_map[item]
@@ -117,15 +128,18 @@ class ExposedObject(object):
 class ExposedObjectCollection(ExposedObject):
     def __init__(self, named_objects):
         """
-        This class helps expose a number of objects (plain or RPCObject) by exposing the methods of each object as
+        This class helps expose a number of objects (plain or RPCObject) by
+        exposing the methods of each object as
 
             name.method
 
-        Furthermore it exposes each object's API as a method with the following name:
+        Furthermore it exposes each object's API as a method with the
+        following name:
 
             name:api
 
-        A list of exposed objects can be obtained by calling the following method from the client:
+        A list of exposed objects can be obtained by calling the following
+        method from the client:
 
             :objects
 
@@ -142,13 +156,16 @@ class ExposedObjectCollection(ExposedObject):
 
     def add_object(self, obj, name):
         if name in self._object_map:
-            raise RuntimeError('An object is already registered under that name.')
+            raise RuntimeError(
+                'An object is already registered under that name.')
 
-        exposed_object = self._object_map[name] = obj if isinstance(obj, ExposedObject) else ExposedObject(obj)
+        exposed_object = self._object_map[name] = \
+            obj if isinstance(obj, ExposedObject) else ExposedObject(obj)
 
         for method_name in exposed_object:
             glue = '.' if not method_name.startswith(':') else ''
-            self._add_function(name + glue + method_name, exposed_object[method_name])
+            self._add_function(name + glue + method_name,
+                               exposed_object[method_name])
 
     def get_objects(self):
         return list(self._object_map.keys())
@@ -157,19 +174,23 @@ class ExposedObjectCollection(ExposedObject):
 class ControlServer(object):
     def __init__(self, object_map=None, host='127.0.0.1', port='10000'):
         """
-        This server opens a ZMQ REP-socket at the given host and port. It constructs an ExposedObjectCollection
-        from the supplied name: object-dictionary and uses that as a handler for JSON-RPC requests. If it is an
-        instance of ExposedObject, that is used directly.
+        This server opens a ZMQ REP-socket at the given host and port.
+        It constructs an ExposedObjectCollection from the supplied
+        name: object-dictionary and uses that as a handler for JSON-RPC
+        requests. If it is an instance of ExposedObject, that is used directly.
 
-        Each time process is called, the server tries to get request data and responds to that. If there is
-        no data, the method does nothing.
+        Each time process is called, the server tries to get request data and
+        responds to that. If there is no data, the method does nothing.
 
-        Please note that this RPC-service comes without any security, authentication, etc. Only use it
-        to expose objects on a trusted network and be aware that anyone on that network can access
-        the exposed objects without any restrictions.
+        Please note that this RPC-service comes without any security,
+        authentication, etc. Only use it to expose objects on a trusted network
+        and be aware that anyone on that network can access the exposed objects
+        without any restrictions.
 
-        :param object_map: Dictionary with name: object-pairs to construct an ExposedObjectCollection or ExposedObject
-        :param host: Host on which the RPC service listens. Default is 127.0.0.1.
+        :param object_map: Dictionary with name: object-pairs to construct an
+        ExposedObjectCollection or ExposedObject
+        :param host: Host on which the RPC service listens.
+        Default is 127.0.0.1.
         :param port: Port on which the RPC service listes.
         """
         super(ControlServer, self).__init__()
@@ -198,21 +219,26 @@ class ControlServer(object):
 
     def process(self):
         """
-        Each time this method is called, the socket tries to retrieve data and passes
-        it to the JSONRPCResponseManager, which in turn passes the RPC to the ExposedObjectCollection.
+        Each time this method is called, the socket tries to retrieve data and
+        passes it to the JSONRPCResponseManager, which in turn passes the RPC
+        to the ExposedObjectCollection.
 
-        In case no data are available, the method does nothing. This behavior is required for
-        Plankton where everything is running in one thread. The central loop can call process
-        at some point to process remote calls, so the RPC-server does not introduce its own
+        In case no data are available, the method does nothing. This behavior
+        is required for Plankton where everything is running in one thread.
+        The central loop can call process at some point to process remote
+        calls, so the RPC-server does not introduce its own
         infinite processing loop.
         """
         try:
             request = self._socket.recv_unicode(flags=zmq.NOBLOCK)
 
             try:
-                response = JSONRPCResponseManager.handle(request, self._rpc_object_collection)
+                response = JSONRPCResponseManager.handle(
+                    request, self._rpc_object_collection)
                 self._socket.send_unicode(response.json)
             except TypeError as e:
-                self._socket.send_json(self._unhandled_exception_response(json.loads(request)['id'], e))
+                self._socket.send_json(
+                    self._unhandled_exception_response(
+                        json.loads(request)['id'], e))
         except zmq.Again:
             pass

--- a/core/processor.py
+++ b/core/processor.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+
 class CanProcess(object):
     """
     The CanProcess class is meant as a base for all things that
@@ -24,13 +25,15 @@ class CanProcess(object):
 
     The base implementation does nothing.
 
-    There are three methods that can be implemented by sub-classes and are called in the process-method in this order:
+    There are three methods that can be implemented by sub-classes and are
+    called in the process-method in this order:
 
         1. doBeforeProcess
         2. doProcess
         3. doAfterProcess
 
-    The doBefore- and doAfterProcess methods are only called if a doProcess-method exists.
+    The doBefore- and doAfterProcess methods are only called if
+    a doProcess-method exists.
     """
 
     def __init__(self):

--- a/core/simulation.py
+++ b/core/simulation.py
@@ -52,19 +52,21 @@ class Simulation(object):
 
         A number of status properties provide information about the simulation.
         The total uptime (in actually elapsed time) can be obtained through the
-        uptime-property, whereas the runtime-property contains the simulated time.
-        The cycles-property indicates the total number of simulation cycles, which
-        does not increase when the simulation is paused.
+        uptime-property, whereas the runtime-property contains the simulated
+        time. The cycles-property indicates the total number of simulation
+        cycles, which does not increase when the simulation is paused.
 
         Finally, the simulation can be stopped entirely with the stop-method.
 
-        All functionality except for the start-method can be made available to remote
-        computers via a ControlServer-instance. This can either be passed to __init__
-        or set as a property before the simulation has been started.
+        All functionality except for the start-method can be made available to
+        remote computers via a ControlServer-instance. This can either be
+        passed to __init__ or set as a property before the simulation
+        has been started.
 
         :param device: The simulated device.
         :param adapter: Adapter which contains the simulated device.
-        :param control_server: ControlServer instance to expose the simulation remotely.
+        :param control_server: ControlServer instance to expose the simulation
+        remotely.
         """
         self._device = device
         self._adapter = adapter
@@ -104,9 +106,9 @@ class Simulation(object):
 
     def _process_cycle(self, delta):
         """
-        Processes one cycle, which consists of one simulation cycle and processing
-        of control server commands. The method measures how long all this takes
-        and returns the elapsed time in seconds.
+        Processes one cycle, which consists of one simulation cycle and
+        processing of control server commands. The method measures how long all
+        this takes and returns the elapsed time in seconds.
 
         :param delta: Elapsed time in last cycle, passed to simulation.
         :return: Elapsed time in this cycle.
@@ -179,9 +181,9 @@ class Simulation(object):
     def speed(self):
         """
         Simulation speed. Actual elapsed time is multiplied with this property
-        to determine simulated time. Values greater than 1 increase the simulation
-        speed, values between 1 and 0 decrease it. A speed of 0 effectively pauses
-        the simulation.
+        to determine simulated time. Values greater than 1 increase the
+        simulation speed, values between 1 and 0 decrease it. A speed of 0
+        effectively pauses the simulation.
         """
         return self._speed
 
@@ -195,25 +197,25 @@ class Simulation(object):
     @property
     def runtime(self):
         """
-        The accumulated simulation time. Whenever speed is different from 1, this
-        progresses at a different rate than uptime.
+        The accumulated simulation time. Whenever speed is different from 1,
+        this progresses at a different rate than uptime.
         """
         return self._runtime
 
     @property
     def device_connected(self):
         """
-        Indicates whether the adapter is processing, i.e. the device is connected.
-        The device simulation can still be running, but if the adapter is not being
-        processed, the device appears disconnected.
+        Indicates whether the adapter is processing, i.e. the device is
+        connected. The device simulation can still be running, but if the
+        adapter is not being processed, the device appears disconnected.
         """
         return self._device_connected
 
     def disconnect_device(self):
         """
-        Simulate disconnecting the device. The simulation continues running, but
-        the outside communication of the device is suspended, so that it appears
-        disconnected.
+        Simulate disconnecting the device. The simulation continues running,
+        but the outside communication of the device is suspended, so that it
+        appears disconnected.
         """
         if not self._device_connected:
             raise RuntimeError('Device is already disconnected.')
@@ -222,8 +224,8 @@ class Simulation(object):
 
     def connect_device(self):
         """
-        Simulate (re-)connecting the device. This is only possible after the device
-        has been virtually disconnected using disconnect_device.
+        Simulate (re-)connecting the device. This is only possible after
+        the device has been virtually disconnected using disconnect_device.
         """
         if self._device_connected:
             raise RuntimeError('Device is already connected.')
@@ -265,21 +267,23 @@ class Simulation(object):
     @property
     def is_paused(self):
         """
-        True if the simulation is paused (implies that the simulation has been started).
+        True if the simulation is paused (implies that the simulation
+        has been started).
         """
         return self._started and not self._running
 
     @property
     def control_server(self):
         """
-        ControlServer-instance that exposes the object to remote machines. Can only
-        be set before start has been called or on a running simulation if no
-        control server was previously present.
+        ControlServer-instance that exposes the object to remote machines.
+        Can only be set before start has been called or on a running simulation
+        if no control server was previously present.
         """
         return self._control_server
 
     @control_server.setter
     def control_server(self, control_server):
         if self.is_started and self._control_server:
-            raise RuntimeError('Can not replace control server while simulation is running.')
+            raise RuntimeError(
+                'Can not replace control server while simulation is running.')
         self._control_server = control_server

--- a/core/statemachine.py
+++ b/core/statemachine.py
@@ -188,8 +188,19 @@ class StateMachine(CanProcess):
         self._initial = cfg['initial']
         self._set_handlers(self._initial)
 
-        # Allow user to explicitly specify state handlers
-        for state_name, handlers in iteritems(cfg.get('states', {})):
+        self._setup_state_handlers(cfg.get('states', {}), context)
+        self._setup_transition_handlers(cfg.get('transitions', {}), context)
+
+    def _setup_state_handlers(self, state_handler_configuration, context):
+        """
+        This method constructs the state handlers from a user-provided dict.
+
+        :param state_handler_configuration: Dictionary with state handler
+        definitions.
+        :param context: Context is provided to state handlers that inherit
+        from HasContext.
+        """
+        for state_name, handlers in iteritems(state_handler_configuration):
             if isinstance(handlers, HasContext):
                 handlers.set_context(context)
 
@@ -208,7 +219,18 @@ class StateMachine(CanProcess):
                     "Failed to parse state handlers for state '%s'. "
                     "Must be dict or iterable." % state_name)
 
-        for states, check_func in iteritems(cfg.get('transitions', {})):
+    def _setup_transition_handlers(self, transition_handler_configuration,
+                                   context):
+        """
+        This method constructs the transition handlers from a user-provided
+        dict.
+
+        :param transition_handler_configuration: Dictionary with transition
+        handler definitions.
+        :param context: Context is provided to transition handlers that inherit
+        from HasContext.
+        """
+        for states, check_func in iteritems(transition_handler_configuration):
             from_state, to_state = states
 
             # Set up default handlers if this state hasn't occured so far

--- a/core/statemachine.py
+++ b/core/statemachine.py
@@ -32,7 +32,8 @@ class HasContext(object):
     """
     Mixin to provide a Context.
 
-    Creates a `_context` member variable that can be assigned with `setContext`.
+    Creates a `_context` member variable that can be assigned with
+    `setContext`.
 
     Any state handler or transition callable that derives from this mixin will
     receive a context from its StateMachine upon initialization (assuming the
@@ -74,9 +75,9 @@ class State(HasContext):
         """
         Handle in-state event.
 
-        Raised repeatedly, once per cycle, while idling in this state. Exactly one
-        in-state event occurs per cycle for every StateMachine. This is always the
-        last event of the cycle.
+        Raised repeatedly, once per cycle, while idling in this state. Exactly
+        one in-state event occurs per cycle for every StateMachine. This is
+        always the last event of the cycle.
 
         :param dt: Delta T since last cycle.
         """
@@ -99,7 +100,8 @@ class Transition(HasContext):
     context. The device context is provided via HasContext mixin, and can be
     accessed as `self._context`.
 
-    To use this class, create a derived class and override the __call__ attribute.
+    To use this class, create a derived class and override the
+    __call__ attribute.
     """
 
     def __init__(self):
@@ -107,12 +109,13 @@ class Transition(HasContext):
 
     def __call__(self):
         """
-        This is invoked when the StateMachine wants to check whether this transition
-        should occur. This happens on cycles when the StateMachine starts the cycle
-        in the source state of this transition.
+        This is invoked when the StateMachine wants to check whether this
+        transition should occur. This happens on cycles when the StateMachine
+        starts the cycle in the source state of this transition.
 
-        If this call returns True, the StateMachine will transition to the destination
-        state. Any remaining transition checks for the source state are not checked.
+        If this call returns True, the StateMachine will transition to the
+        destination state. Any remaining transition checks for the source state
+        are not checked.
 
         :return: True or False / Should transition occur or not
         """
@@ -125,7 +128,8 @@ class StateMachine(CanProcess):
         Cycle based state machine.
 
         :param cfg: dict which contains state machine configuration.
-        :param context: object which is assigned to State and Transition objects as their _context.
+        :param context: object which is assigned to State and Transition
+        objects as their _context.
 
         The configuration dict may contain the following keys:
         - initial: Name of the initial state of this machine
@@ -137,28 +141,40 @@ class StateMachine(CanProcess):
         - list: May contain up to 3 entries, above events in that order.
         - class: Should be an instance of a class that derives from State.
 
-        In case of handlers being provided as a dict or a list, values should be callable
-        and may take a single parameter: the Delta T since the last cycle.
+        In case of handlers being provided as a dict or a list, values should
+        be callable and may take a single parameter: the Delta T since
+        the last cycle.
 
         Transitions should be provided as a dict where:
-        - Each key is a tuple of two values, the FROM and TO states respectively.
-        - Each value is a callable transition condition that return True or False.
+        - Each key is a tuple of two values, the FROM and TO states
+          respectively.
+        - Each value is a callable transition condition that return
+          True or False.
 
-        Transition conditions are called once per cycle when in the FROM state. If one of
-        the transition conditions returns True, the transition is executed that cycle. The
-        remaining conditions aren't called.
+        Transition conditions are called once per cycle when in the FROM state.
+        If one of the transition conditions returns True, the transition is
+        executed that cycle. The remaining conditions aren't called.
 
         Consider using an OrderedDict if order matters.
 
-        Only one transition may occur per cycle. Every cycle will, at the very least,
-        trigger an in_state event against the current state. See process() for details.
+        Only one transition may occur per cycle. Every cycle will, at the very
+        least, trigger an in_state event against the current state.
+
+        See process() for details.
         """
         super(StateMachine, self).__init__()
 
-        self._state = None  # We start outside of any state, first cycle enters initial state
-        self._handler = {}  # Nested dict mapping [state][event] = handler
-        self._transition = {}  # Dict mapping [from_state] = [ (to_state, transition), ... ]
-        self._prefix = {  # Default prefixes used when calling handler functions by name
+        # We start outside of any state, first cycle enters initial state
+        self._state = None
+
+        # Nested dict mapping [state][event] = handler
+        self._handler = {}
+
+        # Dict mapping [from_state] = [ (to_state, transition), ... ]
+        self._transition = {}
+
+        # Default prefixes used when calling handler functions by name
+        self._prefix = {
             'on_entry': '_on_entry_',
             'in_state': '_in_state_',
             'on_exit': '_on_exit_',
@@ -166,7 +182,9 @@ class StateMachine(CanProcess):
 
         # Specifying an initial state is not optional
         if 'initial' not in cfg:
-            raise StateMachineException("StateMachine configuration must include 'initial' to specify starting state.")
+            raise StateMachineException(
+                "StateMachine configuration must include "
+                "'initial' to specify starting state.")
         self._initial = cfg['initial']
         self._set_handlers(self._initial)
 
@@ -177,7 +195,8 @@ class StateMachine(CanProcess):
 
             try:
                 if isinstance(handlers, State):
-                    self._set_handlers(state_name, handlers.on_entry, handlers.in_state, handlers.on_exit)
+                    self._set_handlers(state_name, handlers.on_entry,
+                                       handlers.in_state, handlers.on_exit)
                 elif isinstance(handlers, dict):
                     self._set_handlers(state_name, **handlers)
                 elif hasattr(handlers, '__iter__'):
@@ -186,12 +205,13 @@ class StateMachine(CanProcess):
                     raise
             except:
                 raise StateMachineException(
-                    "Failed to parse state handlers for state '%s'. Must be dict or iterable." % state_name)
+                    "Failed to parse state handlers for state '%s'. "
+                    "Must be dict or iterable." % state_name)
 
         for states, check_func in iteritems(cfg.get('transitions', {})):
             from_state, to_state = states
 
-            # Set up default handlers if this state hasn't been mentioned before
+            # Set up default handlers if this state hasn't occured so far
             if from_state not in self._handler:
                 self._set_handlers(from_state)
             if to_state not in self._handler:
@@ -212,7 +232,8 @@ class StateMachine(CanProcess):
 
     def can(self, state):
         """
-        Returns true if the transition to 'state' is allowed from the current state.
+        Returns true if the transition to 'state' is allowed from
+        the current state.
 
         :param state: State to check transition to
         :return: True if state is reachable from current
@@ -220,34 +241,43 @@ class StateMachine(CanProcess):
         if self._state is None:
             return state == self._initial
 
-        return state in (transition[0] for transition in self._transition[self._state])
+        return state in \
+            (transition[0] for transition in self._transition[self._state])
 
     def bind_handlers_by_name(self, instance, override=False, prefix=None):
         """
         Auto-bind state handlers based on naming convention.
 
-        :param instance: Target object instance to search for handlers and bind events to.
-        :param override: [optional] If set to True, matching handlers will replace previously registered handlers.
-        :param prefix: [optional] Dict of prefixes to override defaults (keys: on_entry, in_state, on_exit)
+        :param instance: Target object instance to search for handlers and bind
+        events to.
+        :param override: [optional] If set to True, matching handlers will
+        replace previously registered handlers.
+        :param prefix: [optional] Dict of prefixes to override defaults
+        (keys: on_entry, in_state, on_exit)
 
-        This function enables automatically binding state handlers to events without having to specify them in the
-        constructor. When called, this function searches `instance` for member functions that match the following
-        patterns for all known states (states mentioned in 'states' or 'transitions' dicts of cfg):
+        This function enables automatically binding state handlers to events
+        without having to specify them in the constructor. When called, this
+        function searches `instance` for member functions that match the
+        following patterns for all known states (states mentioned in 'states'
+        or 'transitions' dicts of cfg):
 
         - instance._on_entry_[state]
         - instance._in_state_[state]
         - instance._on_exit_[state]
 
-        The default prefixes may be overridden using the prefix parameter. Supported keys are 'on_entry', 'in_state',
-        and 'on_exit'. Values should include any and all desired underscores.
+        The default prefixes may be overridden using the prefix parameter.
+        Supported keys are 'on_entry', 'in_state', and 'on_exit'. Values
+        should include any and all desired underscores.
 
-        Matching functions are assigned as handlers to the corresponding state events, iff no handler was previously
-        assigned to that event.
+        Matching functions are assigned as handlers to the corresponding state
+        events, iff no handler was previously assigned to that event.
 
-        If a state event already had a handler assigned (during construction or previous call to this function), no
-        changes are made even if a matching function is found. To force previously assigned handlers to be overwritten,
-        set the third parameter to True. This may be useful to implement inheritance-like specialization using multiple
-        implementation classes but only one StateMachine instance.
+        If a state event already had a handler assigned (during construction or
+        previous call to this function), no changes are made even if a matching
+        function is found. To force previously assigned handlers to be
+        overwritten, set the third parameter to True. This may be useful to
+        implement inheritance-like specialization using multiple implementation
+        classes but only one StateMachine instance.
         """
         if prefix is None:
             prefix = {}
@@ -259,7 +289,8 @@ class StateMachine(CanProcess):
         for state, handlers in iteritems(self._handler):
             for event, handler in iteritems(handlers):
                 if handler is None or override:
-                    named_handler = getattr(instance, prefix[event] + state, None)
+                    named_handler = getattr(instance, prefix[event] + state,
+                                            None)
                     if callable(named_handler):
                         self._handler[state][event] = named_handler
 
@@ -267,24 +298,27 @@ class StateMachine(CanProcess):
         """
         Process a cycle of this state machine.
 
-        :param dt: Delta T. "Time" passed since last cycle, passed on to event handlers.
+        :param dt: Delta T. "Time" passed since last cycle, passed on to event
+        handlers.
 
-        A cycle will perform at most one transition and exactly one in_state event.
+        A cycle will perform at most one transition and exactly one
+        in_state event.
 
-        A transition will only occur if one of the transition condition functions leaving
-        the current state returns True.
+        A transition will only occur if one of the transition condition
+        functions leaving the current state returns True.
 
         When a transition occurs, the following events are raised:
          - on_exit_old_state()
          - on_entry_new_state()
          - in_state_new_state()
 
-        The first cycle after init or reset will never call transition checks and, instead,
-        always performs on_entry and in_state on the initial state.
+        The first cycle after init or reset will never call transition checks
+        and, instead, always performs on_entry and in_state on
+        the initial state.
 
-        Whether a transition occurs or not, and regardless of any other circumstances, a
-        cycle always ends by raising an in_state event on the current (potentially new)
-        state.
+        Whether a transition occurs or not, and regardless of any other
+        circumstances, a cycle always ends by raising an in_state event on the
+        current (potentially new) state.
         """
         # Initial transition on first cycle / after a reset()
         if self._state is None:
@@ -306,7 +340,8 @@ class StateMachine(CanProcess):
 
     def reset(self):
         """
-        Reset the state machine to before the first cycle. The next process() will enter the initial state.
+        Reset the state machine to before the first cycle. The next process()
+        will enter the initial state.
         """
         self._state = None
 
@@ -315,13 +350,18 @@ class StateMachine(CanProcess):
         Add or update state handlers.
 
         :param state: Name of state to be added or updated
-        :param on_entry: Handler for on_entry events. May be None, callable, or list of callables.
-        :param in_state: Handler for in_state events. May be None, callable, or list of callables.
-        :param on_exit: Handler for on_exit events. May be None, callable, or list of callables.
+        :param on_entry: Handler for on_entry events. May be None, callable,
+        or list of callables.
+        :param in_state: Handler for in_state events. May be None, callable,
+        or list of callables.
+        :param on_exit: Handler for on_exit events. May be None, callable,
+        or list of callables.
 
-        Handlers may take up to one parameter (not counting self), delta T since last cycle, and should return nothing.
+        Handlers may take up to one parameter (not counting self), delta T
+        since last cycle, and should return nothing.
 
-        When handlers are omitted or set to None, no event will be raised at all.
+        When handlers are omitted or set to None, no event will be
+        raised at all.
         """
         # Variable arguments for state handlers
         # Default to calling target.on_entry_state_name(), etc
@@ -339,21 +379,26 @@ class StateMachine(CanProcess):
 
         :param from_state: Name of state this transition leaves
         :param to_state: Name of state this transition enters
-        :param transition_check: Callable condition under which this transition occurs. Should return True or False.
+        :param transition_check: Callable condition under which this transition
+        occurs. Should return True or False.
 
-        The transition_check function should return True if the transition should occur. Otherwise, False.
+        The transition_check function should return True if the transition
+        should occur. Otherwise, False.
 
-        Transition condition functions should take no parameters (not counting self).
+        Transition condition functions should take no parameters
+        (not counting self).
         """
         if not callable(transition_check):
-            raise StateMachineException("Transition condition must be callable.")
+            raise StateMachineException(
+                "Transition condition must be callable.")
 
         if from_state not in self._transition.keys():
             self._transition[from_state] = []
 
         # Remove previously added transition with same From -> To mapping
         try:
-            del self._transition[from_state][[x[0] for x in self._transition[from_state]].index(to_state)]
+            del self._transition[from_state][
+                [x[0] for x in self._transition[from_state]].index(to_state)]
         except:
             pass
 
@@ -361,7 +406,8 @@ class StateMachine(CanProcess):
 
     def _raise_event(self, event, dt):
         """
-        Invoke the given event name for the current state, passing dt as a parameter.
+        Invoke the given event name for the current state, passing dt as a
+        parameter.
 
         :param event: Name of event to raise on current state.
         :param dt: Delta T since last cycle.

--- a/core/utils.py
+++ b/core/utils.py
@@ -28,34 +28,39 @@ def get_available_submodules(package, search_path=None):
     This function returns a list of available submodules in a package.
 
     :param package: Name of the package.
-    :param search_path: List of paths to search for package or None. Passed to imp.find_module
+    :param search_path: List of paths to search for package or None.
+    Passed to imp.find_module
     :return: Available submodules in package.
     """
     file_name, path, descriptor = imp.find_module(package, search_path)
 
-    submodule_candidates = [extract_module_name(osp.join(path, entry)) for entry in listdir(path)]
+    submodule_candidates = \
+        [extract_module_name(osp.join(path, entry)) for entry in listdir(path)]
 
-    return [submodule for submodule in submodule_candidates if is_module(submodule, [path])]
+    return [submodule for submodule in submodule_candidates
+            if is_module(submodule, [path])]
 
 
 def extract_module_name(absolute_path):
     """
-    This function tries to extract a valid module name from the basename of the supplied path.
-    If it's a directory, the directory name is returned, if it's a file, the file name
-    without extension is returned. If the basename starts with _ or it's a file with an
-    ending different from .py, the function returns None
+    This function tries to extract a valid module name from the basename of the
+    supplied path. If it's a directory, the directory name is returned, if it's
+    a file, the file name without extension is returned. If the basename starts
+    with _ or it's a file with an ending different from .py, the function
+    returns None
 
     :param absolute_path: Absolute path of something that might be a module.
     :return: Module name or None.
     """
     base_name = osp.basename(osp.normpath(absolute_path))
 
-    # If the basename starts with _ it's probably __init__.py or __pycache__ or something internal.
-    # At the moment there seems to be no use case for those
+    # If the basename starts with _ it's probably __init__.py or __pycache__ or
+    # something internal. At the moment there seems to be no use case for those
     if base_name.startswith('_'):
         return None
 
-    # If it's a directory, there's nothing else to check, so it can be returned directly as the name
+    # If it's a directory, there's nothing else to check, so it can be returned
+    # directly as the name
     if osp.isdir(absolute_path):
         return base_name
 
@@ -70,7 +75,8 @@ def extract_module_name(absolute_path):
 
 def is_module(module, paths):
     """
-    Small helper function that returns True if module is a sub-module in package.
+    Small helper function that returns True if module is a
+    sub-module in package.
 
     :param module: Name of the sub-module to check.
     :param path: List of paths where the module is located.
@@ -85,11 +91,12 @@ def is_module(module, paths):
 
 def dict_strict_update(base_dict, update_dict):
     """
-    This function updates base_dict with update_dict if and only if update_dict does not contain
-    keys that are not already in base_dict. It is essentially a more strict interpretation of the
-    term "updating" the dict.
+    This function updates base_dict with update_dict if and only if update_dict
+    does not contain keys that are not already in base_dict. It is essentially
+    a more strict interpretation of the term "updating" the dict.
 
-    If update_dict contains keys that are not in base_dict, a RuntimeError is raised.
+    If update_dict contains keys that are not in base_dict,
+    a RuntimeError is raised.
 
     :param base_dict: The dict that is to be updated. This dict is modified.
     :param update_dict: The dict containing the new values.
@@ -97,8 +104,8 @@ def dict_strict_update(base_dict, update_dict):
     additional_keys = set(update_dict.keys()) - set(base_dict.keys())
     if len(additional_keys) > 0:
         raise RuntimeError(
-            'The update dictionary contains keys that are not part of the base dictionary: {}'.format(
-                str(additional_keys)))
+            'The update dictionary contains keys that are not '
+            'part of the base dictionary: {}'.format(str(additional_keys)))
 
     base_dict.update(update_dict)
 

--- a/devices/__init__.py
+++ b/devices/__init__.py
@@ -25,12 +25,13 @@ from core.utils import dict_strict_update
 
 class Device(CanProcess):
     """
-    This class exists mainly for consistency. It is meant to implement very simple devices that
-    do not require a state machine for their simulation. For such devices, all that is required
-    is subclassing from `Device` and possibly implementing `doProcess`, but this is optional.
+    This class exists mainly for consistency. It is meant to implement very
+    simple devices that do not require a state machine for their simulation.
+    For such devices, all that is required is subclassing from `Device` and
+    possibly implementing `doProcess`, but this is optional.
 
-    StateMachineDevice offers more functionality and is more likely to be useful for implementing
-    simulations of real devices.
+    StateMachineDevice offers more functionality and is more likely to be
+    useful for implementing simulations of real devices.
     """
 
     def __init__(self):
@@ -38,48 +39,59 @@ class Device(CanProcess):
 
 
 class StateMachineDevice(CanProcessComposite):
-    def __init__(self, override_states=None, override_transitions=None, override_initial_state=None,
-                 override_initial_data=None):
+    def __init__(self, override_states=None, override_transitions=None,
+                 override_initial_state=None, override_initial_data=None):
         """
-        This class is intended to be sub-classed to implement devices using a finite state machine
-        internally.
+        This class is intended to be sub-classed to implement devices using a
+        finite state machine internally.
 
-        Implementing such a device is straightforward, there are three methods that *must* be overriden:
+        Implementing such a device is straightforward, there are three methods
+        that *must* be overriden:
 
             `_get_state_handlers`
             `_get_initial_state`
             `_get_transition_handlers`
 
-        The first method is supposed to return a dictionary with state handlers for each state
-        of the state machine, the second method must return the name of the initial state.
-        The third method must return a dict-like object (often an OrderedDict from collections)
-        that defines the conditions for transitions between the states of the state machine.
+        The first method is supposed to return a dictionary with state handlers
+        for each state of the state machine, the second method must return the
+        name of the initial state. The third method must return a dict-like
+        object (often an OrderedDict from collections) that defines the
+        conditions for transitions between the states of the state machine.
 
-        They are implemented as methods and not as plain class member variables, because often
-        they use the `self`-variable, which does not exist at the class level.
+        They are implemented as methods and not as plain class member
+        variables, because often they use the `self`-variable, which does not
+        exist at the class level.
 
-        From these three methods, a `StateMachine`-instance is constructed, it's available as
-        the device's `_csm`-member. CSM is short for "cycle-based state machine".
+        From these three methods, a `StateMachine`-instance is constructed,
+        it's available as the device's `_csm`-member. CSM is short for
+        "cycle-based state machine".
 
         Most device implementation will also want to override this method:
 
             `_initialize_data`
 
-        This method should initialise device state variables (such as temperature, speed, etc.). Having
-        this in a separate method from `__init__` has the advantage that it can be used to reset those
-        variables at a later stage, without having to write the same code again.
+        This method should initialise device state variables (such as
+        temperature, speed, etc.). Having this in a separate method from
+        `__init__` has the advantage that it can be used to reset those
+        variables at a later stage, without having to write the
+        same code again.
 
-        Following this scheme, inheriting from `StateMachineDevice` also provides the possibility
-        for users of the class to override the states, the transitions, the initial state and
-        even the data. For states, transitions and data, dicts need to be passed to the constructor,
+        Following this scheme, inheriting from `StateMachineDevice` also
+        provides the possibility for users of the class to override the states,
+        the transitions, the initial state and even the data. For states,
+        transitions and data, dicts need to be passed to the constructor,
         for the initial state that should be a string.
 
-        All these overrides can be used to define device setups to describe certain scenarios more easily.
+        All these overrides can be used to define device setups to describe
+        certain scenarios more easily.
 
-        :param override_states: Dict with one entry per state. Only states defined in the state machine are allowed.
-        :param override_transitions: Dict with (state, state) tuples as keys and callables as values.
+        :param override_states: Dict with one entry per state. Only states
+        defined in the state machine are allowed.
+        :param override_transitions: Dict with (state, state) tuples as keys
+        and callables as values.
         :param override_initial_state: The initial state.
-        :param override_initial_data: A dict that contains data members that should be overwritten on construction.
+        :param override_initial_data: A dict that contains data members that
+        should be overwritten on construction.
         """
         super(StateMachineDevice, self).__init__()
 
@@ -87,50 +99,60 @@ class StateMachineDevice(CanProcessComposite):
         self._override_data(override_initial_data)
 
         state_handlers = self._get_final_state_handlers(override_states)
-        initial = self._get_initial_state() if override_initial_state is None else override_initial_state
+        initial = self._get_initial_state() if override_initial_state is None \
+            else override_initial_state
 
-        if not initial in state_handlers:
-            raise RuntimeError('Initial state \'{}\' is not a valid state.'.format(initial))
+        if initial not in state_handlers:
+            raise RuntimeError(
+                'Initial state \'{}\' is not a valid state.'.format(initial))
 
         self._csm = StateMachine({
             'initial': initial,
             'states': state_handlers,
-            'transitions': self._get_final_transition_handlers(override_transitions)
+            'transitions': self._get_final_transition_handlers(
+                override_transitions)
         }, context=self)
 
         self.add_processor(self._csm)
 
     def _get_state_handlers(self):
         """
-        Implement this method to return a dict-like object with state handlers (see core.statemachine.State) for each
-        state of the state machine. The default implementation raises a NotImplementedError.
+        Implement this method to return a dict-like object with state handlers
+        (see core.statemachine.State) for each state of the state machine.
+        The default implementation raises a NotImplementedError.
 
         :return: A dict-like object containing named state handlers.
         """
-        raise NotImplementedError('_get_state_handlers must be implemented in a StateMachineDevice.')
+        raise NotImplementedError(
+            '_get_state_handlers must be implemented in a StateMachineDevice.')
 
     def _get_initial_state(self):
         """
-        Implement this method to return the initial state of the internal state machine. The default implementation
-        raises a NotImplementedError.
+        Implement this method to return the initial state of the internal state
+        machine. The default implementation raises a NotImplementedError.
 
         :return: The initial state of the state machine.
         """
-        raise NotImplementedError('_get_initial_state must be implemented in a StateMachineDevice.')
+        raise NotImplementedError(
+            '_get_initial_state must be implemented in a StateMachineDevice.')
 
     def _get_transition_handlers(self):
         """
-        Implement this method to return transition handlers for the internal state machine. The keys should be
-        (state, state)-tuples and the values functions that return true if the transition should be triggered.
+        Implement this method to return transition handlers for the internal
+        state machine. The keys should be (state, state)-tuples and the values
+        functions that return true if the transition should be triggered.
 
         :return: A dict-like object containing transition handlers.
         """
-        raise NotImplementedError('_get_transition_handlers must be implemented in a StateMachineDevice.')
+        raise NotImplementedError(
+            '_get_transition_handlers must be implemented '
+            'in a StateMachineDevice.')
 
     def _initialize_data(self):
         """
-        Implement this method to initialize data members of the device, such as temperature, speed and others. It gets
-        called first in the __init__-method.
+        Implement this method to initialize data members of the device,
+        such as temperature, speed and others. It gets called first in
+        the __init__-method.
         """
         pass
 
@@ -152,15 +174,17 @@ class StateMachineDevice(CanProcessComposite):
 
     def _override_data(self, overrides):
         """
-        This method overrides data members of the class, but does not allow for adding new members.
+        This method overrides data members of the class, but does not allow for
+        adding new members.
 
         :param overrides: Dict with data overrides.
         """
         if overrides is not None:
             for name, val in overrides.items():
-                if not name in dir(self):
-                    raise AttributeError('Can not override non-existing attribute \'{}\' of class \'{}\'.'.format(
-                        name, type(self).__name__))
+                if name not in dir(self):
+                    raise AttributeError(
+                        'Can not override non-existing attribute \'{}\' of '
+                        'class \'{}\'.'.format(name, type(self).__name__))
 
                 setattr(self, name, val)
 
@@ -173,40 +197,47 @@ def is_device(obj):
 
 def import_device(device, setup=None, device_package='devices'):
     """
-    This function tries to load a given device with a given setup from the package specified
-    in the device_package parameter. First it checks if there is a module
+    This function tries to load a given device with a given setup from the
+    package specified in the device_package parameter. First it checks if
+    there is a module
 
         device_package.device.setups.setup
 
-    and tries to import two members from that module `device_type` and `parameters`. The former
-    must be the device class and the latter the parameters that are passed to the class' constructor.
-    The above mentioned module might look like this:
+    and tries to import two members from that module `device_type` and
+    `parameters`. The former must be the device class and the latter the
+    parameters that are passed to the class' constructor. The above mentioned
+    module might look like this:
 
         from ..device import SomeDeviceClass as device_type
 
         parameters = dict(device_param1='some_value', device_param2=3.4)
 
-    This allows for a large degree of freedom for specifying setups. If that is not required,
-    and the setup does not exist in that sub-module of the device, this function checks for a dictionary
-    named `setups` directly in the device module (device_package.device). So the device_package.device.__init__.py
-    could contain something like this:
+    This allows for a large degree of freedom for specifying setups. If that
+    is not required, and the setup does not exist in that sub-module of the
+    device, this function checks for a dictionary named `setups` directly in
+    the device module (device_package.device).
+    So the device_package.device.__init__.py could contain something like this:
 
         from .device import SomeDeviceClass
 
         setups = dict(
                      default=dict(
                          device_type=SomeDeviceClass,
-                         parameters=dict(device_param1='some_value', device_param2=3.4)
+                         parameters=dict(device_param1='some_value',
+                                         device_param2=3.4)
                      )
                  )
 
-    If that also fails, but no setup was specified in the function's arguments, the function will try to return
-    the first sub-class of `CanProcess` that it finds in the device module. That means in the simplest case,
-    the __init__.py only needs to declare a class that can be instantiated without parameters.
+    If that also fails, but no setup was specified in the function's arguments,
+    the function will try to return the first sub-class of `CanProcess` that it
+    finds in the device module. That means in the simplest case,
+    the __init__.py only needs to declare a class that can be instantiated
+    without parameters.
 
     If all of that fails, an exception is raised.
 
-    Otherwise, a device type and the parameter-dict for object instantiation are returned.
+    Otherwise, a device type and the parameter-dict for object instantiation
+    are returned.
 
     :param device: Device to load.
     :param setup: Setup to load, 'default' will be loaded if parameter is None.
@@ -216,14 +247,16 @@ def import_device(device, setup=None, device_package='devices'):
     setup_name = setup if setup is not None else 'default'
 
     try:
-        setup_module = importlib.import_module('{}.{}.{}.{}'.format(device_package, device, 'setups', setup_name))
+        setup_module = importlib.import_module(
+            '{}.{}.{}.{}'.format(device_package, device, 'setups', setup_name))
         device_type = getattr(setup_module, 'device_type')
         parameters = getattr(setup_module, 'parameters')
 
         return device_type, parameters
     except (ImportError, AttributeError):
         try:
-            device_module = importlib.import_module('{}.{}'.format(device_package, device))
+            device_module = importlib.import_module(
+                '{}.{}'.format(device_package, device))
 
             try:
                 setups = getattr(device_module, 'setups')
@@ -244,4 +277,6 @@ def import_device(device, setup=None, device_package='devices'):
                 raise
 
         except (ImportError, AttributeError, KeyError):
-            raise RuntimeError('Could not find setup \'{}\' for device \'{}\'.'.format(setup_name, device))
+            raise RuntimeError(
+                'Could not find setup \'{}\' for device \'{}\'.'.format(
+                    setup_name, device))

--- a/devices/chopper/__init__.py
+++ b/devices/chopper/__init__.py
@@ -18,3 +18,5 @@
 # *********************************************************************
 
 from .device import SimulatedChopper
+
+__all__ = [SimulatedChopper]

--- a/devices/chopper/__init__.py
+++ b/devices/chopper/__init__.py
@@ -19,4 +19,4 @@
 
 from .device import SimulatedChopper
 
-__all__ = [SimulatedChopper]
+__all__ = ['SimulatedChopper']

--- a/devices/chopper/device.py
+++ b/devices/chopper/device.py
@@ -18,13 +18,10 @@
 # *********************************************************************
 
 from collections import OrderedDict
-
 from core import StateMachine, CanProcess
-
 from devices import StateMachineDevice
-
 from .bearings import MagneticBearings
-from .states import *
+import states
 
 
 class SimulatedBearings(CanProcess, MagneticBearings):
@@ -101,16 +98,16 @@ class SimulatedChopper(StateMachineDevice):
 
     def _get_state_handlers(self):
         return {
-            'init': DefaultInitState(),
+            'init': states.DefaultInitState(),
             'bearings': {'in_state': self._bearings},
-            'stopped': DefaultStoppedState(),
-            'stopping': DefaultStoppingState(),
-            'accelerating': DefaultAcceleratingState(),
-            'phase_locking': DefaultPhaseLockingState(),
-            'phase_locked': DefaultPhaseLockedState(),
-            'idle': DefaultIdleState(),
-            'parking': DefaultParkingState(),
-            'parked': DefaultParkedState(),
+            'stopped': states.DefaultStoppedState(),
+            'stopping': states.DefaultStoppingState(),
+            'accelerating': states.DefaultAcceleratingState(),
+            'phase_locking': states.DefaultPhaseLockingState(),
+            'phase_locked': states.DefaultPhaseLockedState(),
+            'idle': states.DefaultIdleState(),
+            'parking': states.DefaultParkingState(),
+            'parked': states.DefaultParkedState(),
         }
 
     def _get_initial_state(self):
@@ -122,7 +119,8 @@ class SimulatedChopper(StateMachineDevice):
             (('bearings', 'stopped'), lambda: self._bearings.ready),
             (('bearings', 'init'), lambda: self._bearings.idle),
 
-            (('parking', 'parked'), lambda: self.parking_position == self.target_parking_position),
+            (('parking', 'parked'),
+             lambda: self.parking_position == self.target_parking_position),
             (('parking', 'stopping'), lambda: self._stop_commanded),
 
             (('parked', 'stopping'), lambda: self._stop_commanded),
@@ -134,13 +132,15 @@ class SimulatedChopper(StateMachineDevice):
 
             (('accelerating', 'stopping'), lambda: self._stop_commanded),
             (('accelerating', 'idle'), lambda: self._idle_commanded),
-            (('accelerating', 'phase_locking'), lambda: self.speed == self.target_speed),
+            (('accelerating', 'phase_locking'),
+             lambda: self.speed == self.target_speed),
 
             (('idle', 'accelerating'), lambda: self._start_commanded),
             (('idle', 'stopping'), lambda: self._stop_commanded),
 
             (('phase_locking', 'stopping'), lambda: self._stop_commanded),
-            (('phase_locking', 'phase_locked'), lambda: self.phase == self.target_phase),
+            (('phase_locking', 'phase_locked'),
+             lambda: self.phase == self.target_phase),
             (('phase_locking', 'idle'), lambda: self._idle_commanded),
 
             (('phase_locked', 'accelerating'), lambda: self._start_commanded),

--- a/devices/chopper/device.py
+++ b/devices/chopper/device.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from core import StateMachine, CanProcess
 from devices import StateMachineDevice
 from .bearings import MagneticBearings
-import states
+from . import states
 
 
 class SimulatedBearings(CanProcess, MagneticBearings):

--- a/devices/chopper/interfaces/__init__.py
+++ b/devices/chopper/interfaces/__init__.py
@@ -19,4 +19,4 @@
 
 from .epics_interface import ChopperEpicsInterface
 
-__all__ = [ChopperEpicsInterface]
+__all__ = ['ChopperEpicsInterface']

--- a/devices/chopper/interfaces/__init__.py
+++ b/devices/chopper/interfaces/__init__.py
@@ -18,3 +18,5 @@
 # *********************************************************************
 
 from .epics_interface import ChopperEpicsInterface
+
+__all__ = [ChopperEpicsInterface]

--- a/devices/chopper/states.py
+++ b/devices/chopper/states.py
@@ -32,9 +32,10 @@ class DefaultParkingState(State):
         self._parking_speed = parking_speed
 
     def in_state(self, dt):
-        self._context.parking_position = approaches.linear(self._context.parking_position,
-                                                           self._context.target_parking_position,
-                                                           self._parking_speed, dt)
+        self._context.parking_position = \
+            approaches.linear(self._context.parking_position,
+                              self._context.target_parking_position,
+                              self._parking_speed, dt)
 
     def on_entry(self, dt):
         self._context._park_commanded = False
@@ -50,8 +51,8 @@ class DefaultStoppingState(State):
         self._acceleration = acceleration
 
     def in_state(self, dt):
-        self._context.speed = approaches.linear(self._context.speed, 0.0,
-                                                self._acceleration, dt)
+        self._context.speed = \
+            approaches.linear(self._context.speed, 0.0, self._acceleration, dt)
 
     def on_entry(self, dt):
         self._context._stop_commanded = False
@@ -69,8 +70,9 @@ class DefaultIdleState(State):
         self._acceleration = acceleration
 
     def in_state(self, dt):
-        self._context.speed = approaches.linear(self._context.speed, self._context.target_speed,
-                                                self._acceleration, dt)
+        self._context.speed = \
+            approaches.linear(self._context.speed, self._context.target_speed,
+                              self._acceleration, dt)
 
 
 def on_entry(self, dt):
@@ -83,8 +85,9 @@ class DefaultAcceleratingState(State):
         self._acceleration = acceleration
 
     def in_state(self, dt):
-        self._context.speed = approaches.linear(self._context.speed, self._context.target_speed,
-                                                self._acceleration, dt)
+        self._context.speed = \
+            approaches.linear(self._context.speed, self._context.target_speed,
+                              self._acceleration, dt)
 
     def on_entry(self, dt):
         self._context._start_commanded = False
@@ -96,8 +99,9 @@ class DefaultPhaseLockingState(State):
         self._phase_locking_speed = phase_locking_speed
 
     def in_state(self, dt):
-        self._context.phase = approaches.linear(self._context.phase, self._context.target_phase,
-                                                self._phase_locking_speed, dt)
+        self._context.phase = \
+            approaches.linear(self._context.phase, self._context.target_phase,
+                              self._phase_locking_speed, dt)
 
     def on_entry(self, dt):
         self._context._phase_commanded = False

--- a/devices/linkam_t95/__init__.py
+++ b/devices/linkam_t95/__init__.py
@@ -19,4 +19,4 @@
 
 from .device import SimulatedLinkamT95
 
-__all__ = [SimulatedLinkamT95]
+__all__ = ['SimulatedLinkamT95']

--- a/devices/linkam_t95/__init__.py
+++ b/devices/linkam_t95/__init__.py
@@ -18,3 +18,5 @@
 # *********************************************************************
 
 from .device import SimulatedLinkamT95
+
+__all__ = [SimulatedLinkamT95]

--- a/devices/linkam_t95/device.py
+++ b/devices/linkam_t95/device.py
@@ -22,7 +22,7 @@ from collections import OrderedDict
 
 from devices import StateMachineDevice
 
-import states
+from . import states
 
 
 class SimulatedLinkamT95(StateMachineDevice):

--- a/devices/linkam_t95/interfaces/__init__.py
+++ b/devices/linkam_t95/interfaces/__init__.py
@@ -18,3 +18,5 @@
 # *********************************************************************
 
 from .stream_interface import LinkamT95StreamInterface
+
+__all__ = LinkamT95StreamInterface

--- a/devices/linkam_t95/interfaces/__init__.py
+++ b/devices/linkam_t95/interfaces/__init__.py
@@ -19,4 +19,4 @@
 
 from .stream_interface import LinkamT95StreamInterface
 
-__all__ = LinkamT95StreamInterface
+__all__ = ['LinkamT95StreamInterface']

--- a/devices/linkam_t95/interfaces/stream_interface.py
+++ b/devices/linkam_t95/interfaces/stream_interface.py
@@ -37,7 +37,8 @@ class LinkamT95StreamInterface(StreamAdapter):
         """
         Models "T Command" functionality of device.
 
-        Returns all available status information about the device as single byte array.
+        Returns all available status information about the device as
+        single byte array.
 
         :return: Byte array consisting of 10 status bytes.
         """
@@ -67,7 +68,8 @@ class LinkamT95StreamInterface(StreamAdapter):
         Tarray[2] = 0x80 + self._device.pump_speed
 
         # Temperature
-        Tarray[6:10] = [ord(x) for x in "%04x" % (int(self._device.temperature * 10) & 0xFFFF)]
+        Tarray[6:10] = [ord(x) for x in
+                        "%04x" % (int(self._device.temperature * 10) & 0xFFFF)]
 
         return ''.join(chr(c) for c in Tarray)
 
@@ -77,7 +79,8 @@ class LinkamT95StreamInterface(StreamAdapter):
 
         Sets the target rate of temperature change.
 
-        :param param: Rate of temperature change in C/min, multiplied by 100, as a string. Must be positive.
+        :param param: Rate of temperature change in C/min, multiplied by 100,
+        as a string. Must be positive.
         :return: Empty string.
         """
         # TODO: Is not having leading zeroes / 4 digits an error?
@@ -92,7 +95,8 @@ class LinkamT95StreamInterface(StreamAdapter):
 
         Sets the target temperate to be reached.
 
-        :param param: Target temperature in C, multiplied by 10, as a string. Can be negative.
+        :param param: Target temperature in C, multiplied by 10, as a string.
+        Can be negative.
         :return: Empty string.
         """
         # TODO: Is not having leading zeroes / 4 digits an error?
@@ -105,7 +109,8 @@ class LinkamT95StreamInterface(StreamAdapter):
         """
         Models "Start Command" functionality of device.
 
-        Tells the T95 unit to start heating or cooling at the rate specified by setRate and to a limit set by setLimit.
+        Tells the T95 unit to start heating or cooling at the rate specified by
+        set_rate and to a limit set by setLimit.
 
         :return: Empty string.
         """
@@ -127,7 +132,8 @@ class LinkamT95StreamInterface(StreamAdapter):
         """
         Models "Hold Command" functionality of device.
 
-        Device will hold current temperature until a heat or cool command is issued.
+        Device will hold current temperature until a heat or cool command
+        is issued.
 
         :return: Empty string.
         """
@@ -158,7 +164,8 @@ class LinkamT95StreamInterface(StreamAdapter):
         """
         Models "LNP Pump Commands" functionality of device.
 
-        Switches between automatic or manual pump mode, and adjusts speed when in manual mode.
+        Switches between automatic or manual pump mode, and adjusts speed when
+        in manual mode.
 
         :param param: 'a0' for auto, 'm0' for manual, [0-N] for speed.
         :return:

--- a/devices/linkam_t95/states.py
+++ b/devices/linkam_t95/states.py
@@ -39,8 +39,10 @@ class DefaultStartedState(State):
 class DefaultHeatState(State):
     def in_state(self, dt):
         # Approach target temperature at set temperature rate
-        self._context.temperature = approaches.linear(self._context.temperature, self._context.temperature_limit,
-                                                      self._context.temperature_rate / 60.0, dt)
+        self._context.temperature = \
+            approaches.linear(self._context.temperature,
+                              self._context.temperature_limit,
+                              self._context.temperature_rate / 60.0, dt)
 
 
 class DefaultHoldState(State):
@@ -49,12 +51,13 @@ class DefaultHoldState(State):
 
 class DefaultCoolState(State):
     def in_state(self, dt):
-        # TODO: Does manual control work like this? Or is it perhaps a separate state?
+        # TODO: Does manual control work like this? Or is it a separate state?
         if self._context.pump_manual_mode:
             self._context.pump_speed = self._context.manual_target_speed
         else:
             # TODO: Figure out real correlation
-            self._context.pump_speed = 30 * (self._context.temperature_rate / 50.0)
+            self._context.pump_speed = \
+                30 * (self._context.temperature_rate / 50.0)
 
         # Handle "cooling too fast" error
         if self._context.pump_speed > 30:
@@ -66,8 +69,9 @@ class DefaultCoolState(State):
 
         # Approach target temperature at set temperature rate
         # TODO: Should be based on pump speed somehow
-        self._context.temperature = approaches.linear(self._context.temperature, self._context.temperature_limit,
-                                                      self._context.temperature_rate / 60.0, dt)
+        self._context.temperature = approaches.linear(
+            self._context.temperature, self._context.temperature_limit,
+            self._context.temperature_rate / 60.0, dt)
 
     def on_exit(self, dt):
         # If we exit the cooling state, the cooling pump should no longer run

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,1 +1,21 @@
+#  -*- coding: utf-8 -*-
+# *********************************************************************
+# plankton - a library for creating hardware device simulators
+# Copyright (C) 2016 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+
 from __future__ import absolute_import

--- a/examples/example_motor/__init__.py
+++ b/examples/example_motor/__init__.py
@@ -28,8 +28,9 @@ from collections import OrderedDict
 
 class DefaultMovingState(State):
     def in_state(self, dt):
-        self._context.position = approaches.linear(self._context.position, self._context.target,
-                                                   self._context.speed, dt)
+        self._context.position = \
+            approaches.linear(self._context.position, self._context.target,
+                              self._context.speed, dt)
 
 
 class SimulatedExampleMotor(StateMachineDevice):
@@ -81,7 +82,8 @@ class ExampleMotorStreamInterface(StreamAdapter):
         Cmd('get_status', r'^S\?$'),
         Cmd('get_position', r'^P\?$'),
         Cmd('get_target', r'^T\?$'),
-        Cmd('set_target', r'^T=([-+]?[0-9]*\.?[0-9]+)$', argument_mappings=(float,)),
+        Cmd('set_target', r'^T=([-+]?[0-9]*\.?[0-9]+)$',
+            argument_mappings=(float,)),
         Cmd('stop', r'^H$',
             return_mapping=lambda x: 'T={},P={}'.format(x[0], x[1])),
     }
@@ -114,7 +116,7 @@ setups = dict(
         parameters=dict(
             override_initial_state='moving',
             override_initial_data=dict(
-                _target=120.0,position=20.0
+                _target=120.0, position=20.0
             )
         )
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@ mock>=1.0.1
 six
 pyzmq
 json-rpc
+flake8
+nose

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -18,14 +18,11 @@
 # *********************************************************************
 
 
-# Adopted from Mantid:
-# 
 def assertRaisesNothing(testobj, func, *args, **kwargs):
     """
-    unittest does not have an assertRaisesNothing. This function adopted from Mantid
-    (https://github.com/mantidproject/mantid/blob/master/Framework/PythonInterface/test/testhelpers/__init__.py)
-    provides that functionality.
-    
+    unittest does not have an assertRaisesNothing. This function adopted
+    from Mantid's testhelpers module provides that functionality.
+
     :param testobj: A unittest object
     :param func: A callable object
     :param *args: Positional arguments passed to the callable as they are
@@ -34,4 +31,5 @@ def assertRaisesNothing(testobj, func, *args, **kwargs):
     try:
         return func(*args, **kwargs)
     except Exception as exc:
-        testobj.fail("Assertion error. An exception was caught where none was expected in %s. Message: %s" % (func.__name__, str(exc)))
+        testobj.fail('Assertion error. An exception was caught where none was '
+                     'expected in %s. Message: %s' % (func.__name__, str(exc)))

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -27,7 +27,8 @@ class TestCanProcess(unittest.TestCase):
     def test_process_calls_doProcess(self):
         processor = CanProcess()
 
-        with patch.object(processor, 'doProcess', create=True) as doProcessMock:
+        with patch.object(processor, 'doProcess',
+                          create=True) as doProcessMock:
             processor.process(1.0)
 
         doProcessMock.assert_called_once_with(1.0)
@@ -35,7 +36,8 @@ class TestCanProcess(unittest.TestCase):
     def test_process_calls_doBeforeProcess_only_if_doProcess_is_present(self):
         processor = CanProcess()
 
-        with patch.object(processor, 'doBeforeProcess', create=True) as doBeforeProcessMock:
+        with patch.object(processor, 'doBeforeProcess',
+                          create=True) as doBeforeProcessMock:
             processor.process(1.0)
 
             doBeforeProcessMock.assert_not_called()
@@ -48,7 +50,8 @@ class TestCanProcess(unittest.TestCase):
     def test_process_calls_doAfterProcess_only_if_doProcess_is_present(self):
         processor = CanProcess()
 
-        with patch.object(processor, 'doAfterProcess', create=True) as doAfterProcess:
+        with patch.object(processor, 'doAfterProcess',
+                          create=True) as doAfterProcess:
             processor.process(1.0)
 
             doAfterProcess.assert_not_called()
@@ -71,7 +74,8 @@ class TestCanProcessComposite(unittest.TestCase):
     def test_process_calls_doBeforeProcess_if_present(self):
         composite = CanProcessComposite()
 
-        with patch.object(composite, 'doBeforeProcess', create=True) as doBeforeProcessMock:
+        with patch.object(composite, 'doBeforeProcess',
+                          create=True) as doBeforeProcessMock:
             composite.process(3.0)
 
         doBeforeProcessMock.assert_called_once_with(3.0)
@@ -79,7 +83,8 @@ class TestCanProcessComposite(unittest.TestCase):
     def test_addProcessor_if_argument_CanProcess(self):
         composite = CanProcessComposite()
 
-        with patch.object(composite, '_append_processor') as appendProcessorMock:
+        with patch.object(composite,
+                          '_append_processor') as appendProcessorMock:
             composite.add_processor(CanProcess())
 
         self.assertEquals(appendProcessorMock.call_count, 1)
@@ -87,13 +92,15 @@ class TestCanProcessComposite(unittest.TestCase):
     def test_addProcessor_if_argument_not_CanProcess(self):
         composite = CanProcessComposite()
 
-        with patch.object(composite, '_append_processor') as appendProcessorMock:
+        with patch.object(composite,
+                          '_append_processor') as appendProcessorMock:
             composite.add_processor(None)
 
         appendProcessorMock.assert_not_called()
 
     def test_init_from_iterable(self):
-        with patch.object(CanProcess, 'doProcess', create=True) as mockProcessMethod:
+        with patch.object(CanProcess, 'doProcess',
+                          create=True) as mockProcessMethod:
             devices = (CanProcess(), CanProcess(),)
 
             composite = CanProcessComposite(devices)

--- a/test/test_SimulatedChopper.py
+++ b/test/test_SimulatedChopper.py
@@ -24,18 +24,22 @@ from devices.chopper.states import DefaultIdleState
 
 class TestSimulatedChopper(unittest.TestCase):
     def test_invalid_state_override_fails(self):
-        self.assertRaises(RuntimeError, SimulatedChopper, override_states={'invalid': DefaultIdleState()})
+        self.assertRaises(RuntimeError, SimulatedChopper,
+                          override_states={'invalid': DefaultIdleState()})
 
     def test_valid_state_override_does_not_fail(self):
-        chopper = SimulatedChopper(override_states={'idle': DefaultIdleState()})
+        chopper = SimulatedChopper(
+            override_states={'idle': DefaultIdleState()})
 
         self.assertIsInstance(chopper, SimulatedChopper)
 
     def test_invalid_transition_override_fails(self):
         self.assertRaises(RuntimeError, SimulatedChopper,
-                          override_transitions={('idle', 'phase_locking'): lambda: True})
+                          override_transitions={
+                              ('idle', 'phase_locking'): lambda: True})
 
     def test_valid_transition_override_does_not_fail(self):
-        chopper = SimulatedChopper(override_transitions={('idle', 'stopping'): lambda: True})
+        chopper = SimulatedChopper(
+            override_transitions={('idle', 'stopping'): lambda: True})
 
         self.assertIsInstance(chopper, SimulatedChopper)

--- a/test/test_SimulatedLinkamT95.py
+++ b/test/test_SimulatedLinkamT95.py
@@ -20,7 +20,8 @@
 import unittest
 from devices.linkam_t95 import SimulatedLinkamT95
 from devices.linkam_t95.states import DefaultStartedState
-from devices.linkam_t95.interfaces.stream_interface import LinkamT95StreamInterface
+from devices.linkam_t95.interfaces.stream_interface import \
+    LinkamT95StreamInterface
 from . import assertRaisesNothing
 
 
@@ -29,22 +30,31 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         assertRaisesNothing(self, SimulatedLinkamT95)
 
     def test_state_override_construction(self):
-        assertRaisesNothing(self, SimulatedLinkamT95, override_states={'started': DefaultStartedState()})
+        assertRaisesNothing(self, SimulatedLinkamT95,
+                            override_states={'started': DefaultStartedState()})
 
     def test_transition_override_construction(self):
-        assertRaisesNothing(self, SimulatedLinkamT95, override_transitions={('init', 'stopped'): lambda: True})
+        assertRaisesNothing(self, SimulatedLinkamT95,
+                            override_transitions={
+                                ('init', 'stopped'): lambda: True})
 
     def test_default_status(self):
         linkam_device = SimulatedLinkamT95()
         linkam = LinkamT95StreamInterface(linkam_device, None)
         status_bytes = linkam.get_status()
 
-        self.assertEqual(len(status_bytes), 10)     # Byte array should always be 10 bytes
-        self.assertFalse('\x00' in status_bytes)    # Byte array may not contain zeroes
-        self.assertEqual(status_bytes[0], '\x01')   # Status byte should be 1 on startup
-        self.assertEqual(status_bytes[1], '\x80')   # No error flags should be set on startup
-        self.assertEqual(status_bytes[2], '\x80')   # The pump should not be active on startup
-        self.assertEqual(status_bytes[6:10], '00f0')  # Starting temperature 24C
+        # Byte array should always be 10 bytes
+        self.assertEqual(len(status_bytes), 10)
+        # Byte array may not contain zeroes
+        self.assertFalse('\x00' in status_bytes)
+        # Status byte should be 1 on startup
+        self.assertEqual(status_bytes[0], '\x01')
+        # No error flags should be set on startup
+        self.assertEqual(status_bytes[1], '\x80')
+        # The pump should not be active on startup
+        self.assertEqual(status_bytes[2], '\x80')
+        # Starting temperature 24C
+        self.assertEqual(status_bytes[6:10], '00f0')
 
     def test_simple_heat(self):
         linkam_device = SimulatedLinkamT95()
@@ -64,19 +74,19 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         # Heat for almost a minute but not quite
         linkam_device.process(59.5)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[0], '\x10')           # Heating status set
-        self.assertNotEqual(status_bytes[6:10], '01b8')     # Temp != 44.0 C
+        self.assertEqual(status_bytes[0], '\x10')  # Heating status set
+        self.assertNotEqual(status_bytes[6:10], '01b8')  # Temp != 44.0 C
 
         # Finish off heating (and overshoot a bit)
         linkam_device.process(5)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[6:10], '01b8')    # Temp == 44.0 C
+        self.assertEqual(status_bytes[6:10], '01b8')  # Temp == 44.0 C
 
         # Should hold now, so temperature should not change
         linkam_device.process(10)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[0], '\x30')       # Auto-holding at limit
-        self.assertEqual(status_bytes[6:10], '01b8')    # Temp == 44.0 C
+        self.assertEqual(status_bytes[0], '\x30')  # Auto-holding at limit
+        self.assertEqual(status_bytes[6:10], '01b8')  # Temp == 44.0 C
 
     def test_simple_cool(self):
         linkam_device = SimulatedLinkamT95()
@@ -96,19 +106,19 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         # Cool for almost a minute but not quite
         linkam_device.process(59.5)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[0], '\x20')           # Cooling status set
-        self.assertNotEqual(status_bytes[6:10], '0028')     # Temp != 4.0 C
+        self.assertEqual(status_bytes[0], '\x20')  # Cooling status set
+        self.assertNotEqual(status_bytes[6:10], '0028')  # Temp != 4.0 C
 
         # Finish off cooling (and overshoot a bit)
         linkam_device.process(5)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[6:10], '0028')    # Temp == 4.0 C
+        self.assertEqual(status_bytes[6:10], '0028')  # Temp == 4.0 C
 
         # Should hold now, so temperature should not change
         linkam_device.process(10)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[0], '\x30')       # Auto-holding at limit
-        self.assertEqual(status_bytes[6:10], '0028')    # Temp == 4.0 C
+        self.assertEqual(status_bytes[0], '\x30')  # Auto-holding at limit
+        self.assertEqual(status_bytes[6:10], '0028')  # Temp == 4.0 C
 
     def test_error_flag_overcool(self):
         linkam_device = SimulatedLinkamT95()
@@ -156,7 +166,7 @@ class TestSimulatedLinkamT95(unittest.TestCase):
 
         # Ensure status byte reports stopped
         status_bytes = linkam.get_status()
-        self.assertEqual(ord(status_bytes[0]),  0x01)
+        self.assertEqual(ord(status_bytes[0]), 0x01)
 
     def test_hold_and_resume(self):
         linkam_device = SimulatedLinkamT95()
@@ -176,15 +186,15 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         # Cool for a while
         linkam_device.process(30)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[0], '\x20')           # Cooling status set
-        self.assertNotEqual(status_bytes[6:10], '0028')     # Temp != 4.0 C
+        self.assertEqual(status_bytes[0], '\x20')  # Cooling status set
+        self.assertNotEqual(status_bytes[6:10], '0028')  # Temp != 4.0 C
 
         # Hold for a while
         linkam.hold()
         linkam_device.process(30)
         status_bytes = linkam.get_status()
-        self.assertEqual(status_bytes[0], '\x50')           # Manually holding
-        self.assertNotEqual(status_bytes[6:10], '0028')     # Temp != 4.0 C
+        self.assertEqual(status_bytes[0], '\x50')  # Manually holding
+        self.assertNotEqual(status_bytes[6:10], '0028')  # Temp != 4.0 C
 
         # Cool some more
         linkam.cool()
@@ -225,15 +235,20 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         linkam.start()
         linkam_device.process()
 
-        # Since the pump feature is not fully implemented, we can only make sure all valid input is accepted
-        assertRaisesNothing(self, linkam.pump_command, 'm0')    # Manual
+        # Since the pump feature is not fully implemented, we can only make
+        # sure all valid input is accepted
+        assertRaisesNothing(self, linkam.pump_command, 'm0')  # Manual
         linkam_device.process()
 
-        for int_value, char_value in enumerate("0123456789:;<=>?@ABCDEFGHIJKLMN"):
-            assertRaisesNothing(self, linkam.pump_command, char_value)   # Various speeds (characters mean speeds 0 - 30)
+        for int_value, char_value in enumerate(
+                "0123456789:;<=>?@ABCDEFGHIJKLMN"):
+            assertRaisesNothing(
+                self, linkam.pump_command,
+                char_value)  # Various speeds (characters mean speeds 0 - 30)
             linkam_device.process()
             status_bytes = linkam.get_status()
-            self.assertEqual(status_bytes[2], chr(0x80 | int_value))    # Verify Pump Status Byte reflects speed
+            self.assertEqual(status_bytes[2], chr(
+                0x80 | int_value))  # Verify Pump Status Byte reflects speed
 
-        assertRaisesNothing(self, linkam.pump_command, 'a0')    # Auto
+        assertRaisesNothing(self, linkam.pump_command, 'a0')  # Auto
         linkam_device.process()

--- a/test/test_StateMachine.py
+++ b/test/test_StateMachine.py
@@ -33,12 +33,15 @@ class TestStateMachine(unittest.TestCase):
 
     def test_state_machine_starts_in_None(self):
         sm = StateMachine({'initial': 'foobar'})
-        self.assertIsNone(sm.state, "StateMachine should start in the 'None' non-state")
+        self.assertIsNone(sm.state,
+                          "StateMachine should start in the 'None' non-state")
 
     def test_first_cycle_transitions_to_initial(self):
         sm = StateMachine({'initial': 'foobar'})
         sm.process(0.1)
-        self.assertEqual(sm.state, 'foobar', "StateMachine failed to transition into initial state on first cycle")
+        self.assertEqual(sm.state, 'foobar',
+                         "StateMachine failed to transition into "
+                         "initial state on first cycle")
 
     def test_can_transition_with_lambda(self):
         sm = StateMachine({
@@ -94,7 +97,7 @@ class TestStateMachine(unittest.TestCase):
     def test_Transition_receives_Context(self):
         transition = Transition()
         context = object()
-        sm = StateMachine({
+        StateMachine({
             'initial': 'foo',
             'transitions': {
                 ('foo', 'bar'): transition
@@ -110,14 +113,16 @@ class TestStateMachine(unittest.TestCase):
         sm = StateMachine({
             'initial': 'foo',
             'states': {
-                'foo': {'on_entry': on_entry, 'in_state': in_state, 'on_exit': on_exit},
+                'foo': {'on_entry': on_entry, 'in_state': in_state,
+                        'on_exit': on_exit},
             },
             'transitions': {
                 ('foo', 'bar'): lambda: True
             }
         })
 
-        # First cycle enters and executes initial state, but forces delta T to zero
+        # First cycle enters and executes initial state,
+        # but forces delta T to zero
         sm.process(1.0)
         on_entry.assert_called_once_with(0)
         in_state.assert_called_once_with(0)
@@ -151,7 +156,8 @@ class TestStateMachine(unittest.TestCase):
             }
         })
 
-        # First cycle enters and executes initial state, but forces delta T to zero
+        # First cycle enters and executes initial state,
+        # but forces delta T to zero
         sm.process(1.0)
         on_entry.assert_called_once_with(0)
         in_state.assert_called_once_with(0)
@@ -188,7 +194,8 @@ class TestStateMachine(unittest.TestCase):
             }
         })
 
-        # First cycle enters and executes initial state, but forces delta T to zero
+        # First cycle enters and executes initial state,
+        # but forces delta T to zero
         sm.process(1.0)
         foo.on_entry.assert_called_once_with(0)
         foo.in_state.assert_called_once_with(0)
@@ -215,7 +222,7 @@ class TestStateMachine(unittest.TestCase):
     def test_State_receives_Context(self):
         state = State()
         context = object()
-        sm = StateMachine({
+        StateMachine({
             'initial': 'foo',
             'states': {
                 'foo': state
@@ -234,7 +241,8 @@ class TestStateMachine(unittest.TestCase):
         })
         sm.bind_handlers_by_name(target)
 
-        # First cycle enters and executes initial state, but forces delta T to zero
+        # First cycle enters and executes initial state,
+        # but forces delta T to zero
         sm.process(1.0)
         target._on_entry_foo.assert_called_once_with(0)
         target._in_state_foo.assert_called_once_with(0)
@@ -272,7 +280,8 @@ class TestStateMachine(unittest.TestCase):
             'on_exit': 'exit_',
         })
 
-        # First cycle enters and executes initial state, but forces delta T to zero
+        # First cycle enters and executes initial state,
+        # but forces delta T to zero
         sm.process(1.0)
         target.enter_foo.assert_called_once_with(0)
         target.do_foo.assert_called_once_with(0)
@@ -312,7 +321,8 @@ class TestStateMachine(unittest.TestCase):
         sm.bind_handlers_by_name(first)
         sm.bind_handlers_by_name(second, override=True)
 
-        # First cycle enters and executes initial state, but forces delta T to zero
+        # First cycle enters and executes initial state,
+        # but forces delta T to zero
         sm.process(1.0)
         first._on_entry_foo.assert_called_once_with(0)
         first._in_state_foo.assert_called_once_with(0)

--- a/test/test_StateMachineDevice.py
+++ b/test/test_StateMachineDevice.py
@@ -20,7 +20,7 @@
 import unittest
 
 from . import assertRaisesNothing
-from mock import Mock, patch, call
+from mock import Mock, call
 
 from devices import StateMachineDevice
 
@@ -45,15 +45,21 @@ class TestStateMachineDevice(unittest.TestCase):
 
     def test_invalid_initial_override_fails(self):
         assertRaisesNothing(self, MockStateMachineDevice)
-        assertRaisesNothing(self, MockStateMachineDevice, override_initial_state='init')
-        assertRaisesNothing(self, MockStateMachineDevice, override_initial_state='test')
+        assertRaisesNothing(self, MockStateMachineDevice,
+                            override_initial_state='init')
+        assertRaisesNothing(self, MockStateMachineDevice,
+                            override_initial_state='test')
 
-        self.assertRaises(RuntimeError, MockStateMachineDevice, override_initial_state='invalid')
+        self.assertRaises(RuntimeError, MockStateMachineDevice,
+                          override_initial_state='invalid')
 
     def test_overriding_undefined_data_fails(self):
-        assertRaisesNothing(self, MockStateMachineDevice, override_initial_data={'existing_member': 2.0})
+        assertRaisesNothing(self, MockStateMachineDevice,
+                            override_initial_data={'existing_member': 2.0})
 
-        smd = MockStateMachineDevice(override_initial_data={'existing_member': 2.0})
+        smd = MockStateMachineDevice(
+            override_initial_data={'existing_member': 2.0})
         self.assertEqual(smd.existing_member, 2.0)
 
-        self.assertRaises(AttributeError, MockStateMachineDevice, override_initial_data={'nonexisting_member': 1.0})
+        self.assertRaises(AttributeError, MockStateMachineDevice,
+                          override_initial_data={'nonexisting_member': 1.0})

--- a/test/test_approaches.py
+++ b/test/test_approaches.py
@@ -21,6 +21,7 @@ import unittest
 
 from core.approaches import linear
 
+
 class TestApproachLinear(unittest.TestCase):
     def test_target_equals_current_does_not_change(self):
         pos = 34.0

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -22,8 +22,8 @@ import unittest
 from . import assertRaisesNothing
 from mock import Mock, patch, call
 
-
-from core.control_server import ExposedObject, ExposedObjectCollection, ControlServer
+from core.control_server import ExposedObject, ExposedObjectCollection, \
+    ControlServer
 from zmq import Again as zmq_again_exception
 from zmq import NOBLOCK as zmq_no_block_flag
 
@@ -41,7 +41,8 @@ class TestRPCObject(unittest.TestCase):
     def test_all_methods_exposed(self):
         rpc_object = ExposedObject(TestObject())
 
-        expected_methods = [':api', 'a:get', 'a:set', 'b:get', 'b:set', 'getTest', 'setTest']
+        expected_methods = [':api', 'a:get', 'a:set', 'b:get', 'b:set',
+                            'getTest', 'setTest']
         self.assertEqual(len(rpc_object), len(expected_methods))
 
         for method in expected_methods:
@@ -66,7 +67,8 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_selected_and_excluded_methods(self):
-        rpc_object = ExposedObject(TestObject(), members=('a', 'getTest'), exclude=('a'))
+        rpc_object = ExposedObject(TestObject(), members=('a', 'getTest'),
+                                   exclude=('a'))
 
         expected_methods = [':api', 'getTest']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -75,7 +77,8 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_invalid_method_raises(self):
-        self.assertRaises(AttributeError, ExposedObject, TestObject(), ('nonExisting',))
+        self.assertRaises(AttributeError, ExposedObject, TestObject(),
+                          ('nonExisting',))
 
     def test_attribute_wrapper_gets_value(self):
         obj = TestObject()
@@ -127,7 +130,8 @@ class TestExposedObjectCollection(unittest.TestCase):
         self.assertEqual(set(exposed_objects), {':api', 'get_objects'})
 
         self.assertEqual(len(exposed_objects.get_objects()), 0)
-        self.assertEqual(exposed_objects['get_objects'](), exposed_objects.get_objects())
+        self.assertEqual(exposed_objects['get_objects'](),
+                         exposed_objects.get_objects())
 
     def test_api(self):
         exposed_objects = ExposedObjectCollection(named_objects={})
@@ -142,10 +146,13 @@ class TestExposedObjectCollection(unittest.TestCase):
         exposed_objects = ExposedObjectCollection({})
         obj = TestObject()
 
-        assertRaisesNothing(self, exposed_objects.add_object, obj, 'testObject')
+        assertRaisesNothing(self, exposed_objects.add_object, obj,
+                            'testObject')
 
-        # There should be :api, get_objects, testObject:api, testObject.a:get, testObject.a:set,
-        # testObject.b:get, testObject.b:set, testObject.getTest, testObject.setTest
+        # There should be :api, get_objects, testObject:api,
+        # testObject.a:get, testObject.a:set,
+        # testObject.b:get, testObject.b:set,
+        # testObject.getTest, testObject.setTest
         self.assertEqual(len(exposed_objects), 9)
 
         exposed_objects['testObject.getTest'](34, 55)
@@ -155,13 +162,16 @@ class TestExposedObjectCollection(unittest.TestCase):
         exposed_objects = ExposedObjectCollection({})
         obj = TestObject()
 
-        assertRaisesNothing(self, exposed_objects.add_object, ExposedObject(obj, ('setTest', 'getTest')), 'testObject')
+        assertRaisesNothing(self, exposed_objects.add_object,
+                            ExposedObject(obj, ('setTest', 'getTest')),
+                            'testObject')
         exposed_objects['testObject.getTest'](41, 11)
         obj.getTest.assert_called_once_with(41, 11)
 
     def test_nested_collections(self):
         obj = TestObject()
-        exposed_objects = ExposedObjectCollection({'container': ExposedObjectCollection({'test': obj})})
+        exposed_objects = ExposedObjectCollection(
+            {'container': ExposedObjectCollection({'test': obj})})
 
         exposed_objects['container.test.getTest'](454, 43)
         obj.getTest.assert_called_once_with(454, 43)
@@ -172,7 +182,8 @@ class TestControlServer(unittest.TestCase):
     def test_connection(self, mock_socket_method):
         ControlServer(host='127.0.0.1', port='10001')
 
-        mock_socket_method.assert_has_calls([call(), call().bind('tcp://127.0.0.1:10001')])
+        mock_socket_method.assert_has_calls(
+            [call(), call().bind('tcp://127.0.0.1:10001')])
 
     @patch('core.control_server.ControlServer._get_zmq_rep_socket')
     def test_process_does_not_block(self, mock_socket_method):
@@ -184,4 +195,5 @@ class TestControlServer(unittest.TestCase):
         server = ControlServer()
         assertRaisesNothing(self, server.process)
 
-        mock_socket.recv_unicode.assert_has_calls([call(flags=zmq_no_block_flag)])
+        mock_socket.recv_unicode.assert_has_calls(
+            [call(flags=zmq_no_block_flag)])

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -134,7 +134,8 @@ class TestSimulation(unittest.TestCase):
 
     def test_process_calls_control_server(self):
         control_mock = Mock()
-        env = Simulation(device=Mock(), adapter=Mock(), control_server=control_mock)
+        env = Simulation(device=Mock(), adapter=Mock(),
+                         control_server=control_mock)
 
         set_simulation_running(env)
         env._process_cycle(0.5)
@@ -172,7 +173,8 @@ class TestSimulation(unittest.TestCase):
     def test_start_stop(self):
         env = Simulation(device=Mock(), adapter=Mock())
 
-        with patch.object(env, '_process_cycle', side_effect=lambda x: env.stop()) as mock_cycle:
+        with patch.object(env, '_process_cycle',
+                          side_effect=lambda x: env.stop()) as mock_cycle:
             env.start()
 
             mock_cycle.assert_has_calls([call(0.0)])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,10 +18,17 @@
 # *********************************************************************
 
 from six import iteritems
+
 import unittest
 from mock import patch
 
-from core.utils import dict_strict_update
+import os
+import shutil
+import tempfile
+from datetime import datetime
+
+from core.utils import extract_module_name, dict_strict_update, is_module, \
+    get_available_submodules, seconds_since
 
 
 class TestDictStrictUpdate(unittest.TestCase):
@@ -45,12 +52,8 @@ class TestDictStrictUpdate(unittest.TestCase):
         base_dict = {1: 2, 2: 45, 4: 4}
         update_dict = {51: 3, 2: 43}
 
-        self.assertRaises(RuntimeError, dict_strict_update, base_dict, update_dict)
-
-
-from core.utils import extract_module_name
-import os, shutil
-import tempfile
+        self.assertRaises(
+            RuntimeError, dict_strict_update, base_dict, update_dict)
 
 
 class TestWithPackageStructure(unittest.TestCase):
@@ -79,21 +82,23 @@ class TestWithPackageStructure(unittest.TestCase):
         cls._tmp_package_name = os.path.basename(cls._tmp_package)
         cls._tmp_dir = tempfile.gettempdir()
 
-        cls._files = {k: os.path.join(cls._tmp_package, v) for k, v in iteritems(dict(
-            valid='some_file.py',
-            invalid_ext='some_other_file.pyc',
-            invalid_name='_some_invalid_file.py',
-        ))}
+        cls._files = {k: os.path.join(cls._tmp_package, v) for k, v in
+                      iteritems(dict(
+                          valid='some_file.py',
+                          invalid_ext='some_other_file.pyc',
+                          invalid_name='_some_invalid_file.py',
+                      ))}
 
         for abs_file_name in cls._files.values():
             with open(abs_file_name, mode='w'):
                 pass
 
-        cls._dirs = {k: os.path.join(cls._tmp_package, v) for k, v in iteritems(dict(
-            valid='some_dir',
-            empty='empty_dir',
-            invalid='_invalid',
-        ))}
+        cls._dirs = {k: os.path.join(cls._tmp_package, v) for k, v in
+                     iteritems(dict(
+                         valid='some_dir',
+                         empty='empty_dir',
+                         invalid='_invalid',
+                     ))}
 
         for abs_dir_name in cls._dirs.values():
             os.mkdir(abs_dir_name)
@@ -101,7 +106,8 @@ class TestWithPackageStructure(unittest.TestCase):
         with open(os.path.join(cls._tmp_package, '__init__.py'), 'w'):
             pass
 
-        with open(os.path.join(cls._tmp_package, 'some_dir', '__init__.py'), 'w'):
+        with open(os.path.join(cls._tmp_package, 'some_dir', '__init__.py'),
+                  'w'):
             pass
 
         cls._expected_modules = ['some_dir', 'some_file']
@@ -119,46 +125,46 @@ class TestExtractModuleName(TestWithPackageStructure):
         self.assertEqual(extract_module_name(self._dirs['invalid']), None)
 
     def test_file_invalid_name(self):
-        self.assertEqual(extract_module_name(self._files['invalid_name']), None)
+        self.assertEqual(extract_module_name(self._files['invalid_name']),
+                         None)
 
     def test_file_invalid_extension(self):
         self.assertEqual(extract_module_name(self._files['invalid_ext']), None)
 
     def test_file_basename_without_extension(self):
-        self.assertEqual(extract_module_name(self._files['valid']), 'some_file')
-
-
-from core.utils import is_module
+        self.assertEqual(extract_module_name(self._files['valid']),
+                         'some_file')
 
 
 class TestIsModule(TestWithPackageStructure):
     def test_valid_directory(self):
-        self.assertTrue(is_module(extract_module_name(self._dirs['valid']), [self._tmp_package]), self._tmp_package)
+        self.assertTrue(is_module(extract_module_name(self._dirs['valid']),
+                                  [self._tmp_package]), self._tmp_package)
 
     def test_invalid_directory(self):
-        self.assertFalse(is_module(extract_module_name(self._dirs['invalid']), [self._tmp_package]))
+        self.assertFalse(is_module(extract_module_name(self._dirs['invalid']),
+                                   [self._tmp_package]))
 
     def test_invalid_file_name(self):
-        self.assertFalse(is_module(extract_module_name(self._files['invalid_name']), [self._tmp_package]))
+        self.assertFalse(
+            is_module(extract_module_name(self._files['invalid_name']),
+                      [self._tmp_package]))
 
     def test_invalid_file_ext(self):
-        self.assertFalse(is_module(extract_module_name(self._files['invalid_ext']), [self._tmp_package]))
+        self.assertFalse(
+            is_module(extract_module_name(self._files['invalid_ext']),
+                      [self._tmp_package]))
 
     def test_valid_file(self):
-        self.assertTrue(is_module(extract_module_name(self._files['valid']), [self._tmp_package]), self._tmp_package)
-
-
-from core.utils import get_available_submodules
+        self.assertTrue(is_module(extract_module_name(self._files['valid']),
+                                  [self._tmp_package]), self._tmp_package)
 
 
 class TestGetAvailableSubModules(TestWithPackageStructure):
     def test_correct_modules_are_returned(self):
-        self.assertEqual(sorted(get_available_submodules(self._tmp_package_name, [self._tmp_dir])),
-                         sorted(self._expected_modules))
-
-
-from core.utils import seconds_since
-from datetime import datetime
+        self.assertEqual(sorted(
+            get_available_submodules(self._tmp_package_name, [self._tmp_dir])),
+            sorted(self._expected_modules))
 
 
 class TestSecondsSince(unittest.TestCase):


### PR DESCRIPTION
This fixes #124.

All PEP8 issues are resolved now, from now on new code is not allowed to introduce new PEP8 problems. I've arbitrarily set the maximum complexity for functions to 12. Only `import_device` has this value, it should be refactored and the limit set to a lower value (maybe 10?), but that felt a bit outside of the scope for this issue (that function has no test yet). The only code I've refactored because there are tests and it was easy was in `StateMachine.__init__`.

We have to take a look at `core.__init__.py` and so on at some point to make sure `__all__` contains everything we intend to make available.
