### PR TITLE
Remove additional space in coding comment

### DIFF
--- a/plankton-control.py
+++ b/plankton-control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton.py
+++ b/plankton.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/__init__.py
+++ b/plankton/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/__main__.py
+++ b/plankton/__main__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/adapters/__init__.py
+++ b/plankton/adapters/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/adapters/epics.py
+++ b/plankton/adapters/epics.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/adapters/stream.py
+++ b/plankton/adapters/stream.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/__init__.py
+++ b/plankton/core/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/approaches.py
+++ b/plankton/core/approaches.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/control_client.py
+++ b/plankton/core/control_client.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/control_server.py
+++ b/plankton/core/control_server.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/processor.py
+++ b/plankton/core/processor.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/simulation.py
+++ b/plankton/core/simulation.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/statemachine.py
+++ b/plankton/core/statemachine.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/core/utils.py
+++ b/plankton/core/utils.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/__init__.py
+++ b/plankton/devices/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/chopper/__init__.py
+++ b/plankton/devices/chopper/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/chopper/bearings.py
+++ b/plankton/devices/chopper/bearings.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/chopper/device.py
+++ b/plankton/devices/chopper/device.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/chopper/interfaces/__init__.py
+++ b/plankton/devices/chopper/interfaces/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/chopper/interfaces/epics_interface.py
+++ b/plankton/devices/chopper/interfaces/epics_interface.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/chopper/states.py
+++ b/plankton/devices/chopper/states.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/linkam_t95/__init__.py
+++ b/plankton/devices/linkam_t95/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/linkam_t95/device.py
+++ b/plankton/devices/linkam_t95/device.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/linkam_t95/interfaces/__init__.py
+++ b/plankton/devices/linkam_t95/interfaces/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/linkam_t95/interfaces/stream_interface.py
+++ b/plankton/devices/linkam_t95/interfaces/stream_interface.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/devices/linkam_t95/states.py
+++ b/plankton/devices/linkam_t95/states.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/examples/__init__.py
+++ b/plankton/examples/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/examples/example_motor/__init__.py
+++ b/plankton/examples/example_motor/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/examples/simple_device/__init__.py
+++ b/plankton/examples/simple_device/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/scripts/__init__.py
+++ b/plankton/scripts/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/scripts/control.py
+++ b/plankton/scripts/control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/plankton/scripts/run.py
+++ b/plankton/scripts/run.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_SimulatedChopper.py
+++ b/test/test_SimulatedChopper.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_SimulatedLinkamT95.py
+++ b/test/test_SimulatedLinkamT95.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_StateMachine.py
+++ b/test/test_StateMachine.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_StateMachineDevice.py
+++ b/test/test_StateMachineDevice.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_approaches.py
+++ b/test/test_approaches.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_control_client.py
+++ b/test/test_control_client.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # *********************************************************************
 # plankton - a library for creating hardware device simulators
 # Copyright (C) 2016 European Spallation Source ERIC


### PR DESCRIPTION
This fixes #136.

I don't think this requires any further description.
