### PR TITLE
Simulation can construct its own ControlServer

### DIFF
--- a/plankton/core/control_server.py
+++ b/plankton/core/control_server.py
@@ -17,10 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
+from __future__ import absolute_import
+
 import socket
 import zmq
 import json
 from jsonrpc import JSONRPCResponseManager
+
+from .exceptions import PlanktonException
 
 
 class ExposedObject(object):
@@ -190,7 +194,7 @@ class ControlServer(object):
         try:
             self.host = socket.gethostbyname(host)
         except socket.gaierror:
-            raise RuntimeError('Could not resolve control server host: {}'.format(host))
+            raise PlanktonException('Could not resolve control server host: {}'.format(host))
 
         self.port = port
 

--- a/plankton/core/control_server.py
+++ b/plankton/core/control_server.py
@@ -168,7 +168,7 @@ class ExposedObjectCollection(ExposedObject):
 
 
 class ControlServer(object):
-    def __init__(self, object_map=None, host='127.0.0.1', port='10000'):
+    def __init__(self, object_map, connection_string):
         """
         This server opens a ZMQ REP-socket at the given host and port when start_server
         is called.
@@ -186,10 +186,16 @@ class ControlServer(object):
 
         :param object_map: Dictionary with name: object-pairs to construct an
         ExposedObjectCollection or ExposedObject
-        :param host: Host on which the RPC service listens. Default is 127.0.0.1.
-        :param port: Port on which the RPC service listens. Default is 10000.
+        :param connection_string: String with host:port pair for binding control server.
         """
         super(ControlServer, self).__init__()
+
+        try:
+            host, port = connection_string.split(':')
+        except ValueError:
+            raise PlanktonException(
+                '\'{}\' is not a valid control server initialization string. '
+                'A string of the form "host:port" is expected.'.format(connection_string))
 
         try:
             self.host = socket.gethostbyname(host)

--- a/plankton/core/control_server.py
+++ b/plankton/core/control_server.py
@@ -164,10 +164,10 @@ class ExposedObjectCollection(ExposedObject):
 
 
 class ControlServer(object):
-    def __init__(self, object_map=None, host='127.0.0.1', port='10000', start=False):
+    def __init__(self, object_map=None, host='127.0.0.1', port='10000'):
         """
         This server opens a ZMQ REP-socket at the given host and port when start_server
-        is called. If the start-parameter is set to True, this happens directly on construction.
+        is called.
 
         The server constructs an ExposedObjectCollection from the supplied name: object-dictionary
         and uses that as a handler for JSON-RPC requests. If it is an instance of ExposedObject,
@@ -184,7 +184,6 @@ class ControlServer(object):
         ExposedObjectCollection or ExposedObject
         :param host: Host on which the RPC service listens. Default is 127.0.0.1.
         :param port: Port on which the RPC service listens. Default is 10000.
-        :param start: Automatically bind to host and port and start listening.
         """
         super(ControlServer, self).__init__()
 
@@ -201,9 +200,6 @@ class ControlServer(object):
             self._exposed_object = ExposedObjectCollection(object_map)
 
         self._socket = None
-
-        if start:
-            self.start_server()
 
     @property
     def is_running(self):

--- a/plankton/scripts/run.py
+++ b/plankton/scripts/run.py
@@ -22,7 +22,6 @@ import os
 import sys
 
 from plankton.adapters import import_adapter, get_available_adapters
-from plankton.core.control_server import ControlServer, ExposedObject
 from plankton.core.utils import get_available_submodules
 from plankton import __version__
 from plankton.devices import import_device
@@ -33,7 +32,7 @@ from plankton.core.exceptions import PlanktonException
 parser = argparse.ArgumentParser(
     description='Run a simulated device and expose it via a specified communication protocol.')
 
-parser.add_argument('-r', '--rpc-host',
+parser.add_argument('-r', '--rpc-host', default=None,
                     help='HOST:PORT format string for exposing the device via '
                          'JSON-RPC over ZMQ.')
 parser.add_argument('-s', '--setup', default=None,
@@ -99,16 +98,11 @@ def do_run_simulation(argument_list=None):
 
     simulation = Simulation(
         device=device,
-        adapter=adapter)
+        adapter=adapter,
+        control_server=arguments.rpc_host)
 
     simulation.cycle_delay = arguments.cycle_delay
     simulation.speed = arguments.speed
-
-    if arguments.rpc_host:
-        simulation.control_server = ControlServer(
-            {'device': device,
-             'simulation': ExposedObject(simulation, exclude=('start', 'control_server'))},
-            *arguments.rpc_host.split(':'))
 
     simulation.start()
 

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -168,19 +168,10 @@ class TestExposedObjectCollection(unittest.TestCase):
 
 
 class TestControlServer(unittest.TestCase):
-    @patch('plankton.core.control_server.ControlServer.start_server')
-    def test_start_server_behaves_properly(self, start_server_mock):
-        ControlServer()
-        start_server_mock.assert_not_called()
-        ControlServer(start=False)
-        start_server_mock.assert_not_called()
-
-        ControlServer(start=True)
-        start_server_mock.assert_has_calls([call()])
-
     @patch('zmq.Context')
     def test_connection(self, mock_context):
-        ControlServer(host='127.0.0.1', port='10001', start=True)
+        cs = ControlServer(host='127.0.0.1', port='10001')
+        cs.start_server()
 
         mock_context.assert_has_calls([call(), call().socket(zmq.REP),
                                        call().socket().bind('tcp://127.0.0.1:10001')])
@@ -223,7 +214,7 @@ class TestControlServer(unittest.TestCase):
 
     @patch('zmq.Context')
     def test_is_running(self, mock_context):
-        server = ControlServer(start=False)
+        server = ControlServer()
         self.assertFalse(server.is_running)
         server.start_server()
         self.assertTrue(server.is_running)

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -22,7 +22,6 @@ import unittest
 from mock import Mock, patch, call, ANY
 
 from plankton.core.simulation import Simulation
-from plankton.core.control_server import ControlServer
 from . import assertRaisesNothing
 
 
@@ -135,8 +134,10 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(env.runtime, 1.0)
 
     def test_process_calls_control_server(self):
-        control_mock = Mock(spec=ControlServer)
-        env = Simulation(device=Mock(), adapter=Mock(), control_server=control_mock)
+        env = Simulation(device=Mock(), adapter=Mock())
+
+        control_mock = Mock()
+        env._control_server = control_mock
 
         set_simulation_running(env)
         env._process_cycle(0.5)
@@ -163,25 +164,24 @@ class TestSimulation(unittest.TestCase):
                           device=Mock(), adapter=Mock(), control_server='a:b:c')
 
     @patch('plankton.core.simulation.ExposedObject')
-    @patch('plankton.core.simulation.ControlServer.__new__', spec=ControlServer)
+    @patch('plankton.core.simulation.ControlServer')
     def test_construct_control_server(self, mock_control_server_type, exposed_object_mock):
         device = Mock()
         adapter = Mock()
 
         exposed_object_mock.return_value = 'test'
         assertRaisesNothing(self, Simulation, device=device, adapter=adapter,
-                            control_server='localhost')
+                            control_server='localhost:10000')
 
         mock_control_server_type.assert_called_once_with(
-            ControlServer,
             {'device': device, 'simulation': 'test'},
-            'localhost')
+            'localhost:10000')
 
     def test_start_starts_control_server(self):
         env = Simulation(device=Mock(), adapter=Mock())
 
-        control_server_mock = Mock(spec=ControlServer)
-        env.control_server = control_server_mock
+        control_server_mock = Mock()
+        env._control_server = control_server_mock
 
         def process_cycle_side_effect(delta):
             env.stop()
@@ -227,29 +227,39 @@ class TestSimulation(unittest.TestCase):
 
             mock_cycle.assert_has_calls([call(0.0)])
 
-    def test_control_server_setter(self):
-        env = Simulation(device=Mock(), adapter=Mock())
+    @patch('plankton.core.simulation.ExposedObject')
+    @patch('plankton.core.simulation.ControlServer')
+    def test_control_server_setter(self, control_server_mock, exposed_object_mock):
+        # The return value (= instance of ControlServer) must be specified
+        control_server_mock.return_value = Mock()
+        exposed_object_mock.return_value = 'test'
+        device_mock = Mock()
 
-        control_mock = Mock(spec=ControlServer)
-        assertRaisesNothing(self, setattr, env, 'control_server', control_mock)
-        self.assertEqual(env.control_server, control_mock)
+        env = Simulation(device=device_mock, adapter=Mock())
 
-        # The server is not started when the simulation is not running
-        control_mock.assert_not_called()
+        assertRaisesNothing(self, setattr, env, 'control_server', '127.0.0.1:10001')
+        control_server_mock.assert_called_once_with(
+            {'device': device_mock, 'simulation': 'test'}, '127.0.0.1:10001')
+
+        control_server_mock.reset_mock()
 
         assertRaisesNothing(self, setattr, env, 'control_server', None)
         self.assertIsNone(env.control_server)
 
         set_simulation_running(env)
 
-        # Can set new control server even when simulation is running
-        assertRaisesNothing(self, setattr, env, 'control_server', control_mock)
+        # Can set new control server even when simulation is running:
+        assertRaisesNothing(self, setattr, env, 'control_server', '127.0.0.1:10002')
 
         # The server is started automatically when the simulation is running
-        control_mock.assert_has_calls([call.start_server()])
+        control_server_mock.assert_called_once_with(
+            {'device': device_mock, 'simulation': 'test'}, '127.0.0.1:10002')
+
+        # The instance must have one call to start_server
+        control_server_mock.return_value.assert_has_calls([call.start_server()])
 
         # Can not replace control server when simulation is running
-        self.assertRaises(RuntimeError, setattr, env, 'control_server', Mock(spec=ControlServer))
+        self.assertRaises(RuntimeError, setattr, env, 'control_server', '127.0.0.1:10003')
 
     def test_connect_disconnect_exceptions(self):
         env = Simulation(device=Mock(), adapter=Mock())


### PR DESCRIPTION
Simulation now accepts different input, most importantly a `host:port` string from which a ControlServer is constructed. For consistency this is also available via the property setter.

For better control over when the server starts listening, it has to be started explicitly now, either via calling `start_server` or via a new parameter of the constructor called start.

A few more tests have been added around this. Some of the exceptions may be seen by users, those have been converted to `PlanktonException`s.

Fixes #96.