### PR TITLE
Make devices self-documenting

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -175,6 +175,14 @@ $ ./plankton.py -k plankton.examples example_motor -- -b 127.0.0.1 -p 9999
 
 All functionality described in the [Readme](https://github.com/DMSC-Instrument-Data/plankton), such as accessing the device and the simulation via the `plankton-control.py`-script are automatically available.
 
+### User facing documentation
+
+The `StreamAdapter`-class has a property `documentation`, which generates user facing documentation from the `Cmd`-objects (it can be displayed via the `-i`-flag of `plankton.py` or as the `device_documentation`-property of the `simulation`-object via `plankton-control.py`. The regular expression of each command is listed, along with a documentation string. If the `doc`-parameter is provided to `Cmd`, it is used, otherwise the docstring of the wrapped method is used (it does not matter whether the method is part of the device or the interface for feature to work). The latter is the recommended way, because it avoids duplication. But in some cases, the user- and the developer facing documentation may be so different that it's useful to override the docstring.
+
+This is also combined with the docstring of the interface (in this case `ExampleMotorStreamInterface`), and some information about the configured host/port, as well as terminators. The documentation has been left out from the above code samples for brevity, but in the `examples`-directory, the docs are present.
+
+All adapters offer similar functionality, the purpose is that the devices are documented in a way that makes them easy to use by non-developers. This is especially important if the protocol is non-obvious.
+
 ### Unit tests
 
 Unit tests should be added to the `test`-directory. While it would be best to have unit tests for device and interface separately, it is most important that the tests capture overall device behavior, so that it's immediately noticed when a change to Plankton's core parts breaks the simulation. It also makes it easier later on to refactor and change the device.

--- a/plankton/adapters/__init__.py
+++ b/plankton/adapters/__init__.py
@@ -175,5 +175,10 @@ class ForwardMethod(object):
         self._target = target
         self._method = method
 
+        try:
+            self.__doc__ = getattr(self._target, self._method).__doc__
+        except AttributeError:
+            pass
+
     def __call__(self, *args, **kwargs):
         return getattr(self._target, self._method)(*args, **kwargs)

--- a/plankton/adapters/__init__.py
+++ b/plankton/adapters/__init__.py
@@ -18,6 +18,7 @@
 # *********************************************************************
 
 import importlib
+import inspect
 from ..core.exceptions import PlanktonException
 
 
@@ -27,6 +28,10 @@ class Adapter(object):
     def __init__(self, device, arguments=None):
         super(Adapter, self).__init__()
         self._device = device
+
+    @property
+    def documentation(self):
+        return inspect.getdoc(self) or ''
 
     def start_server(self):
         pass

--- a/plankton/adapters/__init__.py
+++ b/plankton/adapters/__init__.py
@@ -113,7 +113,7 @@ def import_adapter(device_name, protocol_name, device_package='devices'):
 
 
 class ForwardProperty(object):
-    def __init__(self, target_member, property_name):
+    def __init__(self, target_member, property_name, instance=None):
         """
         This is a small helper class that can be used to act as
         a forwarding property to relay property setting/getting
@@ -128,7 +128,7 @@ class ForwardProperty(object):
 
             a.forward = 10 # equivalent to a._b.baz = 10
 
-        Note that this modifies the type Baz. Usage must thus be
+        Note that this modifies the type Foo. Usage must thus be
         limited to cases where this type modification is
         acceptable.
 
@@ -137,6 +137,12 @@ class ForwardProperty(object):
         """
         self._target_member = target_member
         self._prop = property_name
+
+        try:
+            self.__doc__ = getattr(type(getattr(instance, self._target_member)),
+                                   self._prop).__doc__
+        except AttributeError:
+            pass
 
     def __get__(self, instance, type=None):
         """
@@ -147,7 +153,10 @@ class ForwardProperty(object):
         :param type: Type.
         :return: Attribute value of member property.
         """
-        return getattr(getattr(instance, self._target_member), self._prop)
+        if instance is not None:
+            return getattr(getattr(instance, self._target_member), self._prop)
+
+        return self
 
     def __set__(self, instance, value):
         """
@@ -157,7 +166,8 @@ class ForwardProperty(object):
         :param instance: Instance of type.
         :param value: Type.
         """
-        setattr(getattr(instance, self._target_member), self._prop, value)
+        if instance is not None:
+            setattr(getattr(instance, self._target_member), self._prop, value)
 
 
 class ForwardMethod(object):

--- a/plankton/adapters/epics.py
+++ b/plankton/adapters/epics.py
@@ -25,9 +25,8 @@ import inspect
 
 from . import Adapter, ForwardProperty
 from six import iteritems
-import textwrap
 
-from plankton.core.utils import seconds_since, FromOptionalDependency
+from plankton.core.utils import seconds_since, FromOptionalDependency, format_doc_text
 from plankton.core.exceptions import PlanktonException
 
 # pcaspy might not be available. To make EPICS-based adapters show up
@@ -171,13 +170,10 @@ class EpicsAdapter(Adapter):
     def documentation(self):
         pv_template = '{} ({}{}):\n{}'
 
-        def wrapped(text):
-            return textwrap.fill(text, width=80, initial_indent='    ', subsequent_indent='    ')
-
         pvs = [pv_template.format(
             self._options.prefix + name,
             pv.config.get('type', 'float'), ', read only' if pv.read_only else '',
-            wrapped(pv.doc or inspect.getdoc(getattr(type(self), pv.property)) or ''))
+            format_doc_text(pv.doc or inspect.getdoc(getattr(type(self), pv.property)) or ''))
                for name, pv in self.pvs.items()]
 
         return '\n\n'.join([inspect.getdoc(self), 'PVs\n==='] + pvs)

--- a/plankton/adapters/epics.py
+++ b/plankton/adapters/epics.py
@@ -21,9 +21,11 @@ from __future__ import print_function
 
 from argparse import ArgumentParser
 from datetime import datetime
+import inspect
 
 from . import Adapter, ForwardProperty
 from six import iteritems
+import textwrap
 
 from plankton.core.utils import seconds_since, FromOptionalDependency
 from plankton.core.exceptions import PlanktonException
@@ -43,7 +45,7 @@ Driver, SimpleServer = FromOptionalDependency(
 
 
 class PV(object):
-    def __init__(self, target_property, poll_interval=1.0, read_only=False, **kwargs):
+    def __init__(self, target_property, poll_interval=1.0, read_only=False, doc=None, **kwargs):
         """
         The PV-class is used to declare the EPICS-interface exposed by a sub-class of
         EpicsAdapter. The target_property argument specifies which property of the adapter
@@ -56,11 +58,13 @@ class PV(object):
         :param target_property: Property of the adapter to expose.
         :param poll_interval: Update interval of the PV.
         :param read_only: Should be True if the PV is read only.
+        :param doc: Description of the PV. If not supplied, docstring of mapped property is used.
         :param kwargs: Arguments forwarded into pcaspy pvdb-dict.
         """
         self.property = target_property
         self.read_only = read_only
         self.poll_interval = poll_interval
+        self.doc = doc
         self.config = kwargs
 
 
@@ -163,6 +167,21 @@ class EpicsAdapter(Adapter):
         self._server = None
         self._driver = None
 
+    @property
+    def documentation(self):
+        pv_template = '{} ({}{}):\n{}'
+
+        def wrapped(text):
+            return textwrap.fill(text, width=80, initial_indent='    ', subsequent_indent='    ')
+
+        pvs = [pv_template.format(
+            self._options.prefix + name,
+            pv.config.get('type', 'float'), ', read only' if pv.read_only else '',
+            wrapped(pv.doc or inspect.getdoc(getattr(type(self), pv.property)) or ''))
+               for name, pv in self.pvs.items()]
+
+        return '\n\n'.join([inspect.getdoc(self), 'PVs\n==='] + pvs)
+
     def start_server(self):
         self._server = SimpleServer()
         self._server.createPV(prefix=self._options.prefix,
@@ -179,7 +198,7 @@ class EpicsAdapter(Adapter):
                 if prop not in dir(self._device):
                     raise AttributeError('Can not find property \''
                                          + prop + '\' in device or interface.')
-                setattr(type(self), prop, ForwardProperty('_device', prop))
+                setattr(type(self), prop, ForwardProperty('_device', prop, instance=self))
 
     def _parseArguments(self, arguments):
         parser = ArgumentParser(description="Adapter to expose a device via EPICS")

--- a/plankton/adapters/epics.py
+++ b/plankton/adapters/epics.py
@@ -176,7 +176,8 @@ class EpicsAdapter(Adapter):
             format_doc_text(pv.doc or inspect.getdoc(getattr(type(self), pv.property)) or ''))
                for name, pv in self.pvs.items()]
 
-        return '\n\n'.join([inspect.getdoc(self), 'PVs\n==='] + pvs)
+        return '\n\n'.join(
+            [inspect.getdoc(self) or '', 'PVs\n==='] + pvs)
 
     def start_server(self):
         self._server = SimpleServer()

--- a/plankton/adapters/epics.py
+++ b/plankton/adapters/epics.py
@@ -168,13 +168,18 @@ class EpicsAdapter(Adapter):
 
     @property
     def documentation(self):
-        pv_template = '{} ({}{}):\n{}'
+        pvs = []
 
-        pvs = [pv_template.format(
-            self._options.prefix + name,
-            pv.config.get('type', 'float'), ', read only' if pv.read_only else '',
-            format_doc_text(pv.doc or inspect.getdoc(getattr(type(self), pv.property)) or ''))
-               for name, pv in self.pvs.items()]
+        for name, pv in self.pvs.items():
+            complete_name = self._options.prefix + name
+
+            data_type = pv.config.get('type', 'float')
+            read_only_tag = ', read only' if pv.read_only else ''
+
+            doc = pv.doc or inspect.getdoc(getattr(type(self), pv.property)) or ''
+
+            pvs.append('{} ({}{}):\n{}'.format(
+                complete_name, data_type, read_only_tag, format_doc_text(doc)))
 
         return '\n\n'.join(
             [inspect.getdoc(self) or '', 'PVs\n==='] + pvs)

--- a/plankton/adapters/stream.py
+++ b/plankton/adapters/stream.py
@@ -105,6 +105,9 @@ class Cmd(object):
         to a string. The default map function only does that when the supplied value
         is not None.
 
+        Finally, documentation can be provided by passing the doc-argument. If it is omitted,
+        the docstring of the bound method is used and if that is not present, left empty.
+
         :param target_method: Method to be called when regex matches.
         :param regex: Regex to match for method call.
         :param regex_flags: Flags to pass ot re.compile, default is 0.
@@ -160,19 +163,19 @@ class StreamAdapter(Adapter):
     def documentation(self):
         cmd_template = '{}:\n{}'
 
-        cmds = [cmd_template.format(
+        commands = [cmd_template.format(
             cmd.pattern.pattern,
             format_doc_text(cmd.doc or inspect.getdoc(getattr(self, cmd.method)) or ''))
-                for cmd in self.commands]
+                    for cmd in self.commands]
 
         options = format_doc_text(
-            'Host: {}\nPort: {}\nRequest terminator: {}\nReply terminator: {}'.format(
+            'Listening on: {}\nPort: {}\nRequest terminator: {}\nReply terminator: {}'.format(
                 self._options.bind_address, self._options.port,
                 repr(self.in_terminator), repr(self.out_terminator)))
 
         return '\n\n'.join(
-            [inspect.getdoc(self) or '', 'Parameters\n==========', options,
-             'Commands\n========'] + cmds)
+            [inspect.getdoc(self) or '',
+             'Parameters\n==========', options, 'Commands\n========'] + commands)
 
     def start_server(self):
         self._server = StreamServer(self._options.bind_address, self._options.port, self)

--- a/plankton/adapters/stream.py
+++ b/plankton/adapters/stream.py
@@ -23,11 +23,13 @@ import asynchat
 import asyncore
 import re
 import socket
+import inspect
 from argparse import ArgumentParser
 
 from six import b
 
 from plankton.adapters import Adapter, ForwardMethod
+from plankton.core.utils import format_doc_text
 
 
 class StreamHandler(asynchat.async_chat):
@@ -86,7 +88,7 @@ class StreamServer(asyncore.dispatcher):
 
 class Cmd(object):
     def __init__(self, target_method, regex, regex_flags=0, argument_mappings=None,
-                 return_mapping=lambda x: None if x is None else str(x)):
+                 return_mapping=lambda x: None if x is None else str(x), doc=None):
         """
         This is a small helper class that makes it easy to define commands that are parsed
         by StreamAdapter and forwarded to the correct methods on the Adapter.
@@ -108,6 +110,7 @@ class Cmd(object):
         :param regex_flags: Flags to pass ot re.compile, default is 0.
         :param argument_mappings: Iterable with mapping functions from string to some type.
         :param return_mapping: Mapping function for return value of method.
+        :param doc: Description of the command. If not supplied, the docstring is used.
         """
         self.method = target_method
         self.pattern = re.compile(b(regex), regex_flags)
@@ -119,6 +122,7 @@ class Cmd(object):
 
         self.argument_mappings = argument_mappings
         self.return_mapping = return_mapping
+        self.doc = doc
 
     def map_arguments(self, arguments):
         """
@@ -152,6 +156,24 @@ class StreamAdapter(Adapter):
 
         self._create_properties(self.commands)
 
+    @property
+    def documentation(self):
+        cmd_template = '{}:\n{}'
+
+        cmds = [cmd_template.format(
+            cmd.pattern.pattern,
+            format_doc_text(cmd.doc or inspect.getdoc(getattr(self, cmd.method)) or ''))
+                for cmd in self.commands]
+
+        options = format_doc_text(
+            'Host: {}\nPort: {}\nRequest terminator: {}\nReply terminator: {}'.format(
+                self._options.bind_address, self._options.port,
+                repr(self.in_terminator), repr(self.out_terminator)))
+
+        return '\n\n'.join(
+            [inspect.getdoc(self) or '', 'Parameters\n==========', format_doc_text(options),
+             'Commands\n========'] + cmds)
+
     def start_server(self):
         self._server = StreamServer(self._options.bind_address, self._options.port, self)
 
@@ -172,7 +194,6 @@ class StreamAdapter(Adapter):
                 if method not in dir(self._device):
                     raise AttributeError('Can not find method \''
                                          + method + '\' in device or interface.')
-
                 setattr(self, method, ForwardMethod(self._device, method))
 
             if cmd.pattern.pattern in patterns:

--- a/plankton/adapters/stream.py
+++ b/plankton/adapters/stream.py
@@ -161,9 +161,8 @@ class StreamAdapter(Adapter):
 
     @property
     def documentation(self):
-        cmd_template = '{}:\n{}'
 
-        commands = [cmd_template.format(
+        commands = ['{}:\n{}'.format(
             cmd.pattern.pattern,
             format_doc_text(cmd.doc or inspect.getdoc(getattr(self, cmd.method)) or ''))
                     for cmd in self.commands]

--- a/plankton/adapters/stream.py
+++ b/plankton/adapters/stream.py
@@ -171,7 +171,7 @@ class StreamAdapter(Adapter):
                 repr(self.in_terminator), repr(self.out_terminator)))
 
         return '\n\n'.join(
-            [inspect.getdoc(self) or '', 'Parameters\n==========', format_doc_text(options),
+            [inspect.getdoc(self) or '', 'Parameters\n==========', options,
              'Commands\n========'] + cmds)
 
     def start_server(self):

--- a/plankton/core/simulation.py
+++ b/plankton/core/simulation.py
@@ -310,5 +310,10 @@ class Simulation(object):
             self._control_server.start_server()
 
     @property
-    def protocol_documentation(self):
+    def device_documentation(self):
+        """
+        This property returns the dynamically created device interface documentation. With the
+        information contained in the documentation it should be obvious to users how to operate
+        the exposed device via its native protocol.
+        """
         return self._adapter.documentation

--- a/plankton/core/simulation.py
+++ b/plankton/core/simulation.py
@@ -308,3 +308,7 @@ class Simulation(object):
 
         if self.is_started and self._control_server is not None:
             self._control_server.start_server()
+
+    @property
+    def protocol_documentation(self):
+        return self._adapter.documentation

--- a/plankton/core/utils.py
+++ b/plankton/core/utils.py
@@ -212,11 +212,11 @@ def format_doc_text(text):
     indentation depth of 4 spaces. Each line is wrapped independently in order to preserve
     manually added line breaks.
 
-    :param text: The text to format
-    :return: The formatted doc text
+    :param text: The text to format, is expected to be cleaned by inspect.cleandoc (for example
+    via inspect.getdoc).
+    :return: The formatted doc text.
     """
 
     return '\n'.join(
         textwrap.fill(line, width=99, initial_indent='    ', subsequent_indent='    ')
-        for line in
-        text.splitlines())
+        for line in text.splitlines())

--- a/plankton/core/utils.py
+++ b/plankton/core/utils.py
@@ -22,6 +22,7 @@ from six import string_types
 
 import imp
 import importlib
+import textwrap
 from datetime import datetime
 
 import os.path as osp
@@ -202,3 +203,20 @@ class FromOptionalDependency(object):
                             for name in names)
 
         return objects if len(objects) != 1 else objects[0]
+
+
+def format_doc_text(text):
+    """
+    A very thin wrapper around textwrap.fill to consistently wrap documentation text
+    for display in a command line environment. The text is wrapped to 99 characters with an
+    indentation depth of 4 spaces. Each line is wrapped independently in order to preserve
+    manually added line breaks.
+
+    :param text: The text to format
+    :return: The formatted doc text
+    """
+
+    return '\n'.join(
+        textwrap.fill(line, width=99, initial_indent='    ', subsequent_indent='    ')
+        for line in
+        text.splitlines())

--- a/plankton/core/utils.py
+++ b/plankton/core/utils.py
@@ -23,6 +23,7 @@ from six import string_types
 import imp
 import importlib
 import textwrap
+import inspect
 from datetime import datetime
 
 import os.path as osp
@@ -212,11 +213,10 @@ def format_doc_text(text):
     indentation depth of 4 spaces. Each line is wrapped independently in order to preserve
     manually added line breaks.
 
-    :param text: The text to format, is expected to be cleaned by inspect.cleandoc (for example
-    via inspect.getdoc).
+    :param text: The text to format, it is cleaned by inspect.cleandoc.
     :return: The formatted doc text.
     """
 
     return '\n'.join(
         textwrap.fill(line, width=99, initial_indent='    ', subsequent_indent='    ')
-        for line in text.splitlines())
+        for line in inspect.cleandoc(text).splitlines())

--- a/plankton/devices/chopper/device.py
+++ b/plankton/devices/chopper/device.py
@@ -155,6 +155,10 @@ class SimulatedChopper(StateMachineDevice):
 
     @property
     def state(self):
+        """
+        The current state of the chopper. This parameter is read-only, it is
+        determined by the internal state machine of the device.
+        """
         return self._csm.state
 
     @property

--- a/plankton/devices/chopper/interfaces/epics_interface.py
+++ b/plankton/devices/chopper/interfaces/epics_interface.py
@@ -21,18 +21,65 @@ from plankton.adapters.epics import EpicsAdapter, PV
 
 
 class ChopperEpicsInterface(EpicsAdapter):
+    """
+    ESS chopper EPICS interface
+
+    Interaction with this interface should happen via ChannelAccess (CA). The PV-names
+    usually carry a prefix which depends on the concrete device and environment, so
+    it is omitted in this description. The dynamically generated description of the PVs
+    does however contain the prefix so that the names can be copy-pasted easily.
+
+    The first step is to initialize the chopper, for example via caput on the command line:
+
+        $ caput CmdS init
+
+    After this, the chopper is in a state where it can be started:
+
+        $ caget State
+        State                          stopped
+
+    To set a specific speed and phase, the setpoints have to be configured via caput:
+
+        $ caput Spd 100
+        $ caput Phs 34.5
+
+    Then the chopper can be commanded to move towards those values:
+
+        $ caput CmdS start
+
+    Now the disc accelerates to the setpoints, the state should now be different:
+
+        $ caget State
+        State                          accelerating
+
+    The possible commands are part of the PV-specific documentation.
+    """
     pvs = {
-        'Spd-RB': PV('target_speed', read_only=True),
-        'Spd': PV('target_speed'),
-        'ActSpd': PV('speed', read_only=True),
+        'Spd-RB': PV('target_speed', read_only=True,
+                     doc='Readback value of the speed setpoint in Hz.'),
+        'Spd': PV('target_speed',
+                  doc='Speed setpoint in Hz.'),
+        'ActSpd': PV('speed', read_only=True,
+                     doc='Current rotation speed of the chopper disc in Hz.'),
 
-        'Phs-RB': PV('target_phase', read_only=True),
-        'Phs': PV('target_phase'),
-        'ActPhs': PV('phase', read_only=True),
+        'Phs-RB': PV('target_phase', read_only=True,
+                     doc='Readback value of phase setpoint in degrees.'),
+        'Phs': PV('target_phase',
+                  doc='Phase setpoint in degrees.'),
+        'ActPhs': PV('phase', read_only=True,
+                     doc='Current phase of the chopper disc in degrees.'),
 
-        'ParkAng-RB': PV('target_parking_position', read_only=True),
-        'ParkAng': PV('target_parking_position'),
-        'AutoPark': PV('auto_park', type='enum', enums=['false', 'true']),
+        'ParkAng-RB': PV('target_parking_position', read_only=True,
+                         doc='Readback value of the discs parking position setpoint in degrees.'),
+        'ParkAng': PV('target_parking_position',
+                      doc='The discs parking position setpoint in degrees.'),
+        'AutoPark': PV('auto_park',
+                       doc='If enabled, the chopper disc will be moved to the parking '
+                           'position automatically when the speed is 0 or the chopper '
+                           'is otherwise stopped. 0 means False, 1 means True, the string '
+                           'representations of the enum values are "false" and "true".',
+                       type='enum', enums=['false', 'true']),
+
         'State': PV('state', read_only=True, type='string'),
 
         'CmdS': PV('execute_command', type='string'),
@@ -51,6 +98,10 @@ class ChopperEpicsInterface(EpicsAdapter):
 
     @property
     def execute_command(self):
+        """
+        Command to execute. Possible commands are start, stop, set_phase,
+        unlock, park, init, deinit.
+        """
         return ''
 
     @execute_command.setter
@@ -62,4 +113,7 @@ class ChopperEpicsInterface(EpicsAdapter):
 
     @property
     def last_command(self):
+        """
+        The last command that was executed successfully.
+        """
         return self._last_command

--- a/plankton/devices/linkam_t95/interfaces/stream_interface.py
+++ b/plankton/devices/linkam_t95/interfaces/stream_interface.py
@@ -21,6 +21,19 @@ from plankton.adapters.stream import StreamAdapter, Cmd
 
 
 class LinkamT95StreamInterface(StreamAdapter):
+    """
+    Linkam T95 TCP stream interface
+
+    This is the interface of a simulated Linkam T95 device. The device listens on a configured
+    host:port-combination, one option to connect to it is via telnet:
+
+        $ telnet host port
+
+    Once connected, it's possible to send the specified commands, described in the dynamically
+    generated documentation. Information about host, port and line terminators in the concrete
+    device instance are also generated dynamically.
+    """
+
     commands = {
         Cmd('get_status', '^T$'),
         Cmd('set_rate', '^R1([0-9]+)$'),

--- a/plankton/examples/simple_device/__init__.py
+++ b/plankton/examples/simple_device/__init__.py
@@ -27,6 +27,17 @@ class VerySimpleDevice(Device):
 
 
 class VerySimpleInterface(StreamAdapter):
+    """
+    A very simple device with TCP-stream interface
+
+    The device has only one parameter, which can be set to an arbitrary
+    value. The interface consists of two commands which can be invoked via telnet.
+    To connect:
+
+        $ telnet host port
+
+    After that, typing either of the commands and pressing enter sends them to the server.
+    """
     commands = {
         Cmd('get_param', '^P$'),
         Cmd('set_param', '^P=(.+)$'),
@@ -36,9 +47,11 @@ class VerySimpleInterface(StreamAdapter):
     out_terminator = '\r\n'
 
     def get_param(self):
+        """Returns the device parameter."""
         return self._device.param
 
     def set_param(self, new_param):
+        """Set the device parameter, does not return anything."""
         self._device.param = new_param
 
     def handle_error(self, request, error):

--- a/plankton/scripts/run.py
+++ b/plankton/scripts/run.py
@@ -39,6 +39,8 @@ parser.add_argument('-s', '--setup', default=None,
                     help='Name of the setup to load.')
 parser.add_argument('-l', '--list-protocols',
                     help='List available protocols for selected device.', action='store_true')
+parser.add_argument('-i', '--show-interface', action='store_true',
+                    help='Show command interface of device interface.')
 parser.add_argument('-p', '--protocol', default=None,
                     help='Communication protocol to expose devices.')
 parser.add_argument('-c', '--cycle-delay', type=float, default=0.1,
@@ -98,6 +100,10 @@ def do_run_simulation(argument_list=None):
     adapter = import_adapter(
         arguments.device, arguments.protocol,
         device_package=arguments.device_package)(device, arguments.adapter_args)
+
+    if arguments.show_interface:
+        print(adapter.documentation)
+        return
 
     simulation = Simulation(
         device=device,

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -302,3 +302,12 @@ class TestSimulation(unittest.TestCase):
         env._process_cycle(0.5)
         adapter_mock.assert_has_calls([call.handle(env.cycle_delay)])
         sleep_mock.assert_not_called()
+
+    def test_device_documentation_returns_adapter_documentation(self):
+        adapter_mock = Mock()
+        adapter_mock.documentation = 'test'
+
+        env = Simulation(device=Mock(), adapter=adapter_mock)
+        doc = env.device_documentation
+
+        self.assertEqual(doc, 'test')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -28,7 +28,9 @@ from mock import patch
 from six import iteritems
 
 from plankton.core.utils import dict_strict_update, extract_module_name, \
-    is_module, seconds_since, get_available_submodules, FromOptionalDependency
+    is_module, seconds_since, get_available_submodules, FromOptionalDependency, \
+    format_doc_text
+
 from plankton.core.exceptions import PlanktonException
 
 
@@ -215,3 +217,27 @@ class TestFromOptionalDependency(unittest.TestCase):
 
     def test_exception_does_not_accept_arbitrary_type(self):
         self.assertRaises(RuntimeError, FromOptionalDependency, 'invalid_module', 6.0)
+
+
+class TestFormatDocText(unittest.TestCase):
+    def test_lines_are_preserved_and_indented(self):
+        text = 'This is\na test\nwith multiple lines.'
+        expected = '    This is\n    a test\n    with multiple lines.'
+        self.assertEqual(format_doc_text(text), expected)
+
+    def test_indented_lines_are_cleaned_up(self):
+        text = '  This is\n  a test\n  with multiple lines.'
+        expected = '    This is\n    a test\n    with multiple lines.'
+        self.assertEqual(format_doc_text(text), expected)
+
+    def test_long_lines_are_broken(self):
+        text = ' '.join(['ab'] * 44)
+        expected = '    ' + ' '.join(['ab'] * 32) + '\n' + '    ' + ' '.join(['ab'] * 12)
+
+        self.assertEqual(format_doc_text(text), expected)
+
+    def test_no_lines_above_99(self):
+        text = ' '.join(['abc'] * 143)
+        converted = format_doc_text(text).split('\n')
+
+        self.assertTrue(all([len(line) <= 99 for line in converted]))


### PR DESCRIPTION
This fixes #141.

This is my suggestion for "self-documenting" devices. `Adapter` now has an additional property `documentation` which can be overridden in sub-classes. For now I've decided against adding stuff to the class doc-string for several reasons, the most important being that the type of the interface is modified on construction and so it depends on the device and/or configuration (PV-prefix, host/port, ...).

Both `EpicsAdapter` and `StreamAdapter` auto-generate command lists from the `PV`/`Cmd`-objects. These now have `doc`-parameter that can be used to document a command explicitly. If `doc` is not supplied, the docstring of the wrapped/exposed property or method is used, no matter if it's on the device or the interface.

For both adapters, the interface class doc-string is included in the documentation, in the `StreamAdapter`-case also information about host, port, terminators.

To query a device before running it there is a new script parameter:

```
$ ./plankton.py -i chopper -- -p Chopper1:
```

It's also exposed via the `ControlServer`, as the `device_documentation`-property of the `simulation`-object. It made more sense to me to put it there that in the device, because it's related to the interface, not the device.

@dmichel76, is this along the lines you had in mind?

I'll leave the `In progress`-label on for a while so we can discuss.