### PR TITLE
Commenting out pcaspy in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-pcaspy
 six
 pyzmq
 json-rpc
+
+# If you plan on using devices with EPICS interface, uncomment the pcaspy-line.
+# Installation of pcaspy requires a working EPICS installation,
+# please check the pcaspy-docs at https://pcaspy.readthedocs.io/en/latest/
+#pcaspy


### PR DESCRIPTION
We're treating this as an optional dependency now, so it shouldn't be necessary for users to edit this file if they don't want to install it. If they do, they have to enable this dependency explicitly.