### PR TITLE
Add check_limits decorator to core.utils

### DIFF
--- a/plankton/core/exceptions.py
+++ b/plankton/core/exceptions.py
@@ -29,3 +29,10 @@ class PlanktonException(Exception):
     from unexpected ones. This enables better error handling and more importantly
     better presentation of errors to the users.
     """
+
+
+class LimitViolationException(Exception):
+    """
+    An exception that can be raised in a device to indicate a limit violation. It is for example
+    raised by the :class:`~plankton.core.utils.check_limits`.
+    """

--- a/plankton/core/utils.py
+++ b/plankton/core/utils.py
@@ -29,6 +29,7 @@ import imp
 import importlib
 import textwrap
 import inspect
+import functools
 from datetime import datetime
 
 import os.path as osp
@@ -296,6 +297,7 @@ class check_limits(object):
         self._silent = silent
 
     def __call__(self, f):
+        @functools.wraps(f)
         def limit_checked(obj, new_value):
             low = getattr(obj, self._lower) if isinstance(self._lower,
                                                           string_types) else self._lower

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -25,10 +25,9 @@ from . import assertRaisesNothing, TestWithPackageStructure
 from mock import patch
 from six import string_types
 
-from plankton.core.exceptions import PlanktonException
 from plankton.core.utils import dict_strict_update, extract_module_name, \
     get_submodules, get_members, seconds_since, FromOptionalDependency, \
-    format_doc_text check_limits
+    format_doc_text, check_limits
 
 from plankton.core.exceptions import PlanktonException, LimitViolationException
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -285,3 +285,22 @@ class TestCheckLimits(unittest.TestCase):
 
         assertRaisesNothing(self, f.set_bar, -3)
         assertRaisesNothing(self, f.set_bar, 16)
+
+    def test_silent_mode(self):
+        class Foo(object):
+            bar = 0
+
+            @check_limits(0, 15, silent=True)
+            def set_bar(self, new_bar):
+                self.bar = new_bar
+
+        f = Foo()
+
+        assertRaisesNothing(self, f.set_bar, 0)
+        assertRaisesNothing(self, f.set_bar, 15)
+
+        assertRaisesNothing(self, f.set_bar, -3)
+        assertRaisesNothing(self, f.set_bar, 16)
+
+        # Updates must have been ignored.
+        self.assertEquals(f.bar, 15)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -205,6 +205,31 @@ class TestCheckLimits(unittest.TestCase):
         self.assertRaises(LimitViolationException, f.set_bar, -3)
         self.assertRaises(LimitViolationException, f.set_bar, 16)
 
+    def test_upper_lower_only(self):
+        class Foo(object):
+            bar = 0
+            baz = 1
+
+            @check_limits(upper=15)
+            def set_bar(self, new_bar):
+                self.bar = new_bar
+
+            @check_limits(lower=0)
+            def set_baz(self, new_baz):
+                self.baz = new_baz
+
+        f = Foo()
+
+        assertRaisesNothing(self, f.set_bar, 0)
+        assertRaisesNothing(self, f.set_bar, 15)
+        assertRaisesNothing(self, f.set_bar, -5)
+        self.assertRaises(LimitViolationException, f.set_bar, 16)
+
+        assertRaisesNothing(self, f.set_baz, 0)
+        assertRaisesNothing(self, f.set_baz, 15)
+        assertRaisesNothing(self, f.set_baz, 16)
+        self.assertRaises(LimitViolationException, f.set_baz, -5)
+
     def test_property_limits(self):
         class Foo(object):
             bar = 0
@@ -228,6 +253,12 @@ class TestCheckLimits(unittest.TestCase):
 
         assertRaisesNothing(self, f.set_bar, -3)
         assertRaisesNothing(self, f.set_bar, 16)
+
+        f.bar_min = None
+        f.bar_max = None
+
+        assertRaisesNothing(self, f.set_bar, 123232224)
+        assertRaisesNothing(self, f.set_bar, -352622234)
 
     def test_silent_mode(self):
         class Foo(object):


### PR DESCRIPTION
This has no issue number, but it came up while experimenting with the socket device.

A new decorator is introduced called `check_limits`, which can check the parameter passed to a unary function. The main intention was use on property setters:

```
class Foo(object):
    _bar = 5

    @property
    def bar(self):
        return self._bar

    @bar.setter
    @check_limits(-4.0, 6.7)
    def bar(self, new_bar):
        self._bar = new_bar
```

For more flexibility regarding updating limits at runtime either of the limits can be a string, which is then assumed to be a plain data member of the object:

```
class Foo(object):
    _bar = 5
    _bar_min = -4.0

    @property
    def bar(self):
        return self._bar

    @bar.setter
    @check_limits('_bar_min', 6.7)
    def bar(self, new_bar):
        self._bar = new_bar
```

You can also suppress the exception by supplying `silent=True` to the decorator. This would be useful for the interface of the linkam (could also profit from `argument_mappings`):

```
    # Cmd('set_limit', ..., argument_mappings=(int,), return_mapping=lambda x: "" if x is None else str(x))
    @check_limits(-2000, 6000, silent=True):
    def set_limit(self, limit):
        self._device.temperature_limit = limit / 10.0
```