### PR TITLE
Update documentation to reflect new installation method

### DIFF
--- a/docs/user_guide/remote_access_devices.rst
+++ b/docs/user_guide/remote_access_devices.rst
@@ -10,7 +10,7 @@ the ``-r`` option with a ``host:port`` string to the simulation:
 
 ::
 
-    $ python lewis.py -r 127.0.0.1:10000 chopper -- -p SIM:
+    $ lewis -r 127.0.0.1:10000 chopper -- -p SIM:
 
 Now the device can be controlled via the ``lewis-control.py``-script
 in a different terminal window. The service can be queried to show the
@@ -18,7 +18,7 @@ available objects by not supplying an object name:
 
 ::
 
-    $ python lewis-control.py -r 127.0.0.1:10000
+    $ lewis-control -r 127.0.0.1:10000
 
 The ``-r`` (or ``--rpc-host``) option defaults to the value shown here,
 so it will be omitted in the following examples. To get information on
@@ -27,7 +27,7 @@ method will list the object's API:
 
 ::
 
-    $ python lewis-control.py device
+    $ lewis-control device
 
 This will output a list of properties and methods which is available for
 remote access. This may not comprise the full interface of the object
@@ -36,13 +36,13 @@ property is done like this:
 
 ::
 
-    $ python lewis-control.py device state
+    $ lewis-control device state
 
 The same syntax is used to call methods without parameters:
 
 ::
 
-    $ python lewis-control.py device initialize
+    $ lewis-control device initialize
 
 To set a property to a new value, the value has to be supplied on the
 command line:
@@ -53,7 +53,7 @@ command line:
     $ python lewis-control.py device start
 
 Only numeric types and strings can be used as arguments via the
-``lewis-control.py``-script. The script always tries to convert
+``lewis-control``-script. The script always tries to convert
 parameters to ``int`` first, then to ``float`` and leaves it as ``str``
 if both fail. For other types and more control over types, it's advised
 to write a Python script instead using the tools provided in

--- a/docs/user_guide/remote_access_devices.rst
+++ b/docs/user_guide/remote_access_devices.rst
@@ -1,4 +1,4 @@
-Remote access to devices
+Remote Access to Devices
 ========================
 
 *Please note that this functionality should only be used on a trusted
@@ -49,15 +49,54 @@ command line:
 
 ::
 
-    $ python lewis-control.py device target_speed 100
-    $ python lewis-control.py device start
+    $ lewis-control device target_speed 100
+    $ lewis-control device start
 
-Only numeric types and strings can be used as arguments via the
-``lewis-control``-script. The script uses the Python rules for parsing literals,
-so ints, floats, tuples, lists, dicts are submitted to the server. For more complex types
-and more control, it's advised to write a Python script instead using
-the tools provided in ``lewis.core.control_client`` which makes it possible to use the
-remote objects more or less transparently. An example to control the chopper:
+Value Interpretation and Syntax
+-------------------------------
+
+``lewis_control`` interprets values as built-in Python literals or containers using
+`ast.literal_eval <https://docs.python.org/3/library/ast.html#ast.literal_eval>`__. This means any
+syntax for literal evaluation supported by Python works here as well. The following are all valid
+values which are interpreted as you might expect:
+
+::
+
+    $ lewis-control device float_value 12.0
+    $ lewis-control device float_value .5
+    $ lewis-control device float_value 1.23e10
+    $ lewis-control device int_value 123
+    $ lewis-control device int_value 0xDEADBEEF
+    $ lewis-control device int_value 010  # Value of 8 in base 8 (octal)
+    $ lewis-control device str_value hello_world
+    $ lewis-control device method_call_with_two_string_args hello world
+    $ lewis-control device str_value "hello world"
+    $ lewis-control device unicode_value "u'hello_world'"
+    $ lewis-control device list_value "[1,2,3]"
+    $ lewis-control device list_value "['a', 'b', 'c']"
+    $ lewis-control device dict_value "{'a': 1, 'b': 2}"
+
+WARNING: Any value that cannot be successfully evaluated is silently converted into a
+string literal instead! The following attempts turn into strings because the letters
+are not quoted:
+
+::
+
+    $ lewis-control device str_value_looks_like_dict "{a: 1, b: 2}"
+    $ lewis-control device str_value_looks_like_list "[a, b, c]"
+
+This is done for convenience, to avoid having to double quote and/or escape quote trivial string
+values to match Python syntax while also taking shell quotation and escapes into account. But it
+can lead to unexpected results at times.
+
+Control Client Python API
+-------------------------
+
+For use cases that require more flexibility and control, it is advised to write a Python script
+using the API provided in ``lewis.core.control_client`` instead of using the command line utility.
+This makes it possible to use the remote objects in a fairly transparent fashion.
+
+Here is a brief example using the ``chopper`` device:
 
 .. code:: python
 
@@ -74,3 +113,12 @@ remote objects more or less transparently. An example to control the chopper:
         sleep(0.1)
 
     chopper.start()
+
+All calls, reads and assignments are synchronous and blocking in terms of the methods and
+attributes they access on the server. However, much like with real devices, the behaviour of the
+simulated device is asynchronous from its interface. Consequently, depending on the specific
+device, some effects of calling a method may take place long after the method is called (and
+returns).
+
+This is why, in the above example, a loop is used to wait for ``chopper.state`` to change in
+response to the ``chopper.initialize()`` call.

--- a/docs/user_guide/remote_access_devices.rst
+++ b/docs/user_guide/remote_access_devices.rst
@@ -53,13 +53,11 @@ command line:
     $ python lewis-control.py device start
 
 Only numeric types and strings can be used as arguments via the
-``lewis-control``-script. The script always tries to convert
-parameters to ``int`` first, then to ``float`` and leaves it as ``str``
-if both fail. For other types and more control over types, it's advised
-to write a Python script instead using the tools provided in
-``lewis.core.control_client`` which makes it possible to use the
-remote objects more or less transparently. An example to control the
-chopper:
+``lewis-control``-script. The script uses the Python rules for parsing literals,
+so ints, floats, tuples, lists, dicts are submitted to the server. For more complex types
+and more control, it's advised to write a Python script instead using
+the tools provided in ``lewis.core.control_client`` which makes it possible to use the
+remote objects more or less transparently. An example to control the chopper:
 
 .. code:: python
 

--- a/docs/user_guide/remote_access_simulation.rst
+++ b/docs/user_guide/remote_access_simulation.rst
@@ -10,8 +10,8 @@ simulation can be paused and resumed using the control script:
 
 ::
 
-    $ ./lewis-control.py simulation pause
-    $ ./lewis-control.py simulation resume
+    $ lewis-control simulation pause
+    $ lewis-control simulation resume
 
 With these commands, the simulation is paused, while the communication
 with the device remains responsive. The communication channel (for
@@ -21,8 +21,8 @@ loss of connection, another pair of functions is available:
 
 ::
 
-    $ ./lewis-control.py simulation disconnect_device
-    $ ./lewis-control.py simulation connect_device
+    $ lewis-control simulation disconnect_device
+    $ lewis-control simulation connect_device
 
 This basically shows the opposite effect, the device simulation
 continues running, but the communication channel is not processed
@@ -34,8 +34,8 @@ parameter).
 
 ::
 
-    $ ./lewis-control.py simulation speed 10
-    $ ./lewis-control.py simulation cycle_delay 0.05
+    $ lewis-control simulation speed 10
+    $ lewis-control simulation cycle_delay 0.05
 
 This will cause the twice as many cycles per second to be computed
 compared to the default, and the simulation runs ten times faster than
@@ -47,14 +47,14 @@ passed:
 
 ::
 
-    $ ./lewis-control.py simulation uptime
-    $ ./lewis-control.py simulation runtime
+    $ lewis-control simulation uptime
+    $ lewis-control simulation runtime
 
 Finally, the simulation can also be stopped:
 
 ::
 
-    $ ./lewis-control.py simulation stop
+    $ lewis-control simulation stop
 
 It is not possible to recover from that, as the processing of remote
 commands stops as well. The only way to restart the simulation is to run

--- a/docs/user_guide/remote_access_simulation.rst
+++ b/docs/user_guide/remote_access_simulation.rst
@@ -1,4 +1,4 @@
-Remote access to simulation parameters
+Remote Access to Simulation Parameters
 ======================================
 
 *Please note that this functionality should only be used on a trusted

--- a/docs/user_guide/usage_with_python.rst
+++ b/docs/user_guide/usage_with_python.rst
@@ -1,13 +1,100 @@
 Usage with Python
 =================
 
-To use Lewis directly via Python you must first install its
-dependencies:
+To use Lewis directly via Python you must first install its dependencies:
 
 -  Python 2.7+ or 3.4+
 -  PIP 8.1+
 
-Clone the repository in a location of your choice:
+On most linux systems these can be installed via the distribution's package manager.
+
+Virtual environments
+--------------------
+
+The two sections below describe installation and use of Lewis using two different methods,
+installation via pip and from source. For both methods we recommend setting up a virtual
+environment, which provide a great way of keeping packages outside the system directories and
+at the same time have more control over the environment a script is running in.
+
+To setup a virtual environment, you need the ``virtualenv`` package:
+
+::
+
+    $ pip install --user virtualenv
+
+After that it's recommended to create a directory somewhere to hold the environments:
+
+::
+
+    $ mkdir ~/venvs
+
+Then you can create a new environment using the virtualenv command:
+
+::
+
+    $ virtualenv ~/venvs/lewis-env
+
+To actually begin using the environment, a script file containing environment variables and so on
+needs to be sourced:
+
+::
+
+    $ source ~/venvs/lewis-env/bin/activate
+
+By default this modifies the terminal display, showing the name of the environment. To leave the
+environment and go back to the "normal" terminal type the following:
+
+::
+
+    (lewis-env)$ deactivate
+
+The packages that are installed in the virtual environment are only available when it has been
+activated. Inside the virtual environment you do not need the ``--user``-flag of pip, because
+the directories the packages are installed to are in a location that is writable with your
+normal user account.
+
+There are some packages to make managing multiple virtual environments easier and some IDEs also
+have builtin support. A number of guides and documentation pages exist on this topic, the
+documentation of virtualenv is a good starting point (`<https://virtualenv.pypa.io/en/stable/>`__).
+
+
+Installation via pip
+--------------------
+
+Lewis is available on the `Python Package Index <https://pypi.python.org/pypi/lewis>`__. That means
+it can be installed using pip:
+
+::
+
+    $ pip install lewis
+
+This will install lewis along with its dependencies. If you would like to use EPICS based devices
+and have a working EPICS environment on your machine, you can install it like this to get the
+additional required dependencies:
+
+::
+
+    $ pip install lewis[epics]
+
+This will install two scripts in the path, ``lewis`` and ``lewis-control``. Both scripts provide
+command line help:
+
+::
+
+    $ lewis --help
+    $ lewis-control --help
+
+To list available devices, just type ``lewis`` in the command line, a list of devices that are
+available for simulation will be printed.
+
+All following sections of this user manual assume that Lewis has been installed via pip and that
+the ``lewis`` command is available.
+
+Installation from source
+------------------------
+
+Clone the repository in a location of your choice, we recommend that you do it inside a virtual
+environment (see above) so that you can keep track of the dependencies:
 
 ::
 
@@ -27,7 +114,6 @@ out in the ``requirements.txt``-file and have to be explicitly enabled. Currentl
 dependency is ``pcaspy`` for using devices with an EPICS interface, it requires a working
 installation of EPICS base. Please refer to the `installation instructions
 <https://pcaspy.readthedocs.io/en/latest/installation.html>`__ of the module.
-
 
 If you also want to run Lewis' unit tests, you may also install the
 development dependencies:
@@ -64,3 +150,6 @@ directory):
 
 Details about parameters for the various adapters, and differences
 between OSes are covered in the "Adapter Specifics" sections.
+
+If you decided to install Lewis this way, please be aware that the ``lewis`` and ``lewis-control``
+calls in the other parts of the guide have to be replaced with ``python lewis.py``.


### PR DESCRIPTION
Now that the package is available on PyPI, the user guide was updated to reflect that change. I also added a very brief section on virtual environments, with a link to the documentation of the `virtualenv` package for further details.

Please build the documentation locally and check that the pages look okay and that the text makes sense.

This closes #162.