### PR TITLE
Capitalized Lewis where Plankton was capitalized

### DIFF
--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -27,13 +27,13 @@ from . import Adapter, ForwardProperty
 from six import iteritems
 
 from lewis.core.utils import seconds_since, FromOptionalDependency, format_doc_text
-from lewis.core.exceptions import lewisException
+from lewis.core.exceptions import LewisException
 
 # pcaspy might not be available. To make EPICS-based adapters show up
 # in the listed adapters anyway dummy types are created in this case
 # and the failure is postponed to runtime, where a more appropriate
-# lewisException can be raised.
-missing_pcaspy_exception = lewisException(
+# LewisException can be raised.
+missing_pcaspy_exception = LewisException(
     'In order to use EPICS-interfaces, pcaspy must be installed:\n'
     '\tpip install pcaspy\n'
     'A fully working installation of EPICS-base is required for this package. '

--- a/lewis/core/control_server.py
+++ b/lewis/core/control_server.py
@@ -18,7 +18,7 @@
 # *********************************************************************
 
 """
-This module contains classes to expose objects via a JSON-RPC over ZMQ server. lewis uses
+This module contains classes to expose objects via a JSON-RPC over ZMQ server. Lewis uses
 this infrastructure in :class:`~lewis.core.simulation.Simulation`.
 
 .. seealso::
@@ -35,7 +35,7 @@ import zmq
 import json
 from jsonrpc import JSONRPCResponseManager
 
-from .exceptions import lewisException
+from .exceptions import LewisException
 
 
 class ExposedObject(object):
@@ -222,14 +222,14 @@ class ControlServer(object):
         try:
             host, port = connection_string.split(':')
         except ValueError:
-            raise lewisException(
+            raise LewisException(
                 '\'{}\' is not a valid control server initialization string. '
                 'A string of the form "host:port" is expected.'.format(connection_string))
 
         try:
             self.host = socket.gethostbyname(host)
         except socket.gaierror:
-            raise lewisException('Could not resolve control server host: {}'.format(host))
+            raise LewisException('Could not resolve control server host: {}'.format(host))
 
         self.port = port
 
@@ -278,7 +278,7 @@ class ControlServer(object):
         ExposedObjectCollection.
 
         In case no data are available, the method does nothing. This behavior is required for
-        lewis where everything is running in one thread. The central loop can call process
+        Lewis where everything is running in one thread. The central loop can call process
         at some point to process remote calls, so the RPC-server does not introduce its own
         infinite processing loop.
 

--- a/lewis/core/devices.py
+++ b/lewis/core/devices.py
@@ -27,7 +27,7 @@ produces factory-like objects that create device instances and interfaces based 
 import importlib
 
 from lewis.adapters import Adapter
-from lewis.core.exceptions import lewisException
+from lewis.core.exceptions import LewisException
 from lewis.core.utils import get_submodules, get_members
 
 
@@ -244,7 +244,7 @@ class DeviceBuilder(object):
     def create_device(self, setup=None):
         """
         Creates a device object according to the provided setup. If no setup is provided,
-        the default setup is used. If the setup can't be found, a lewisException is raised.
+        the default setup is used. If the setup can't be found, a LewisException is raised.
         This can also happen if the device type specified in the setup is invalid.
 
         :param setup: Name of the setup from which to create device.
@@ -253,7 +253,7 @@ class DeviceBuilder(object):
         setup_name = setup if setup is not None else 'default'
 
         if setup_name not in self.setups:
-            raise lewisException(
+            raise LewisException(
                 'Failed to find setup \'{}\' for device \'{}\'. '
                 'Available setups are:\n    {}'.format(
                     setup, self.name, '\n    '.join(self.setups.keys())))
@@ -265,7 +265,7 @@ class DeviceBuilder(object):
             return self._create_device_instance(
                 device_type, **setup_data.get('parameters', {}))
         except RuntimeError:
-            raise lewisException(
+            raise LewisException(
                 'The setup \'{}\' you tried to load does not specify a valid device type, but the '
                 'device module \'{}\' provides multiple device types so that no meaningful '
                 'default can be deduced.'.format(setup_name, self.name))
@@ -273,7 +273,7 @@ class DeviceBuilder(object):
     def create_interface(self, protocol=None, *args, **kwargs):
         """
         Returns an interface that implements the provided protocol. If the protocol is not
-        known, a lewisException is raised. All additional arguments are forwarded
+        known, a LewisException is raised. All additional arguments are forwarded
         to the interface constructor (see :class:`~lewis.adapters.Adapter` for details).
 
         :param protocol: Protocol which the interface must implement.
@@ -286,7 +286,7 @@ class DeviceBuilder(object):
         try:
             return self.interfaces[protocol](*args, **kwargs)
         except KeyError:
-            raise lewisException(
+            raise LewisException(
                 'Failed to find protocol \'{}\' for device \'{}\'. '
                 'Available protocols are: \n    {}'.format(
                     protocol, self.name, '\n    {}'.join(self.interfaces.keys())))
@@ -307,7 +307,7 @@ class DeviceRegistry(object):
 
         # construct device, interface, ...
 
-    If the module can not be imported, a lewisException is raised.
+    If the module can not be imported, a LewisException is raised.
 
     :param device_module: Name of device module from which devices are loaded.
     """
@@ -316,7 +316,7 @@ class DeviceRegistry(object):
         try:
             self._device_module = importlib.import_module(device_module)
         except ImportError:
-            raise lewisException(
+            raise LewisException(
                 'Failed to import module \'{}\' for device discovery. '
                 'Make sure that it is in the PYTHONPATH.\n'
                 'See also the -a option of lewis.'.format(device_module))
@@ -333,7 +333,7 @@ class DeviceRegistry(object):
         """
         Returns a :class:`DeviceBuilder` instance that can be used to create device objects
         based on setups, as well as device interfaces. If the device name is not stored
-        in the internal map, a lewisException is raised.
+        in the internal map, a LewisException is raised.
 
         :param name: Name of the device.
         :return: :class:`DeviceBuilder`-object for requested device.
@@ -341,7 +341,7 @@ class DeviceRegistry(object):
         try:
             return self._devices[name]
         except KeyError:
-            raise lewisException(
+            raise LewisException(
                 'No device with the name \'{}\' could be found. '
                 'Possible names are:\n    {}\n'
                 'See also the -k option to add inspect a different module.'.format(

--- a/lewis/core/exceptions.py
+++ b/lewis/core/exceptions.py
@@ -23,7 +23,7 @@ that they can be caught and meaningful messages can be displayed to the user.
 """
 
 
-class lewisException(Exception):
+class LewisException(Exception):
     """
     This exception type is used to distinguish exceptions that are expected
     from unexpected ones. This enables better error handling and more importantly

--- a/lewis/core/utils.py
+++ b/lewis/core/utils.py
@@ -34,7 +34,7 @@ from datetime import datetime
 from os import path as osp
 from os import listdir
 
-from .exceptions import lewisException, LimitViolationException
+from .exceptions import LewisException, LimitViolationException
 
 
 def get_submodules(module):
@@ -191,8 +191,8 @@ class FromOptionalDependency(object):
     case an exception is raised.
 
     The exception can be controlled via the exception-parameter. If it is a
-    string, a lewisException is constructed from it. Alternatively it can
-    be an instance of an exception-type. If not provided, a lewisException
+    string, a LewisException is constructed from it. Alternatively it can
+    be an instance of an exception-type. If not provided, a LewisException
     with a standard message is constructed. If it is anything else, a RuntimeError
     is raised.
 
@@ -200,7 +200,7 @@ class FromOptionalDependency(object):
     the module that was attempted to load is actually used.
 
     :param module: Module from that symbols should be imported.
-    :param exception: Text for lewisException or custom exception object.
+    :param exception: Text for LewisException or custom exception object.
     """
 
     def __init__(self, module, exception=None):
@@ -211,7 +211,7 @@ class FromOptionalDependency(object):
                         'functionality you tried to use.'.format(self._module)
 
         if isinstance(exception, string_types):
-            exception = lewisException(exception)
+            exception = LewisException(exception)
 
         if not isinstance(exception, BaseException):
             raise RuntimeError(

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -25,7 +25,7 @@ from lewis import __version__
 
 from lewis.core.devices import DeviceRegistry
 from lewis.core.simulation import Simulation
-from lewis.core.exceptions import lewisException
+from lewis.core.exceptions import LewisException
 
 parser = argparse.ArgumentParser(
     description='Run a simulated device and expose it via a specified communication protocol.')
@@ -110,12 +110,12 @@ def do_run_simulation(argument_list=None):
 def run_simulation(argument_list=None):
     """
     This function is just a very thin wrapper around do_run_simulation to catch expected
-    exceptions that are derived from lewisException.
+    exceptions that are derived from LewisException.
 
     :param argument_list: Argument list to pass to the argument parser declared in this module.
     :return:
     """
     try:
         do_run_simulation(argument_list)
-    except lewisException as e:
+    except LewisException as e:
         print('\n'.join(('An error occurred:', e.message)))

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -24,7 +24,7 @@ import zmq
 import socket
 
 from lewis.core.control_server import ExposedObject, ExposedObjectCollection, ControlServer
-from lewis.core.exceptions import lewisException
+from lewis.core.exceptions import LewisException
 from . import assertRaisesNothing
 
 
@@ -222,14 +222,14 @@ class TestControlServer(unittest.TestCase):
         self.assertTrue(server.is_running)
 
     @patch('lewis.core.control_server.socket.gethostbyname')
-    def test_invalid_hostname_raises_lewisException(self, gethostbyname_mock):
+    def test_invalid_hostname_raises_LewisException(self, gethostbyname_mock):
         def raise_exception(self):
             raise socket.gaierror
 
         gethostbyname_mock.side_effect = raise_exception
 
         self.assertRaises(
-            lewisException, ControlServer,
+            LewisException, ControlServer,
             object_map=None, connection_string='some_invalid_host.local:10000')
 
         gethostbyname_mock.assert_called_once_with('some_invalid_host.local')

--- a/test/test_core_devices.py
+++ b/test/test_core_devices.py
@@ -22,7 +22,7 @@ from . import assertRaisesNothing, TestWithPackageStructure
 
 from lewis.core.devices import is_device, is_adapter, \
     DeviceRegistry, DeviceBuilder, DeviceBase
-from lewis.core.exceptions import lewisException
+from lewis.core.exceptions import LewisException
 from lewis.devices import Device, StateMachineDevice
 from lewis.adapters import Adapter
 from lewis.adapters.stream import StreamAdapter
@@ -122,7 +122,7 @@ class TestDeviceBuilderSimpleModule(unittest.TestCase):
         device = builder.create_device()
         self.assertIsInstance(device, self.module.DummyDevice)
 
-        self.assertRaises(lewisException, builder.create_device, 'invalid_setup')
+        self.assertRaises(LewisException, builder.create_device, 'invalid_setup')
 
     def test_create_interface(self):
         builder = DeviceBuilder(self.module)
@@ -133,7 +133,7 @@ class TestDeviceBuilderSimpleModule(unittest.TestCase):
         self.assertIsInstance(
             builder.create_interface('dummy', device=device), self.module.DummyAdapter)
 
-        self.assertRaises(lewisException, builder.create_interface, 'invalid_protocol')
+        self.assertRaises(LewisException, builder.create_interface, 'invalid_protocol')
 
 
 class TestDeviceBuilderMultipleDevicesAndProtocols(unittest.TestCase):
@@ -181,8 +181,8 @@ class TestDeviceBuilderMultipleDevicesAndProtocols(unittest.TestCase):
     def test_create_device(self):
         builder = DeviceBuilder(self.module)
 
-        self.assertRaises(lewisException, builder.create_device)
-        self.assertRaises(lewisException, builder.create_device, 'default')
+        self.assertRaises(LewisException, builder.create_device)
+        self.assertRaises(LewisException, builder.create_device, 'default')
 
 
 class TestDeviceBuilderComplexModule(unittest.TestCase):
@@ -256,7 +256,7 @@ class TestDeviceBuilderWithDuplicateProtocols(unittest.TestCase):
 class TestDeviceRegistry(TestWithPackageStructure):
     def test_init(self):
         assertRaisesNothing(self, DeviceRegistry, self._tmp_package_name)
-        self.assertRaises(lewisException, DeviceRegistry, str(uuid4()))
+        self.assertRaises(LewisException, DeviceRegistry, str(uuid4()))
 
     def test_devices(self):
         registry = DeviceRegistry(self._tmp_package_name)
@@ -272,4 +272,4 @@ class TestDeviceRegistry(TestWithPackageStructure):
         builder = registry.device_builder('some_file')
         self.assertEquals(builder.name, 'some_file')
 
-        self.assertRaises(lewisException, registry.device_builder, 'invalid_device')
+        self.assertRaises(LewisException, registry.device_builder, 'invalid_device')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,7 +29,7 @@ from lewis.core.utils import dict_strict_update, extract_module_name, \
     get_submodules, get_members, seconds_since, FromOptionalDependency, \
     format_doc_text, check_limits
 
-from lewis.core.exceptions import lewisException, LimitViolationException
+from lewis.core.exceptions import LewisException, LimitViolationException
 
 
 class TestDictStrictUpdate(unittest.TestCase):
@@ -146,13 +146,13 @@ class TestFromOptionalDependency(unittest.TestCase):
         self.assertEqual(A.__name__, 'A')
         self.assertEqual(B.__name__, 'B')
 
-        self.assertRaises(lewisException, A, 'argument_one')
-        self.assertRaises(lewisException, B, 'argument_one', 'argument_two')
+        self.assertRaises(LewisException, A, 'argument_one')
+        self.assertRaises(LewisException, B, 'argument_one', 'argument_two')
 
     def test_string_exception_is_raised(self):
         A = FromOptionalDependency('invalid_module', 'test').do_import('A')
 
-        self.assertRaises(lewisException, A)
+        self.assertRaises(LewisException, A)
 
     def test_custom_exception_is_raised(self):
         A = FromOptionalDependency('invalid_module', ValueError('test')).do_import('A')


### PR DESCRIPTION
Noticed that `PlanktonException` was renamed into `lewisException` rather than `LewisException`. This PR fixes this, plus a couple of comments where `Plankton` turned into `lewis`.