### PR TITLE
EPICS meta data can be updated at runtime

### DIFF
--- a/docs/release_notes/release_1_0_2.rst
+++ b/docs/release_notes/release_1_0_2.rst
@@ -20,6 +20,10 @@ New features
    that expose lambda-functions, named functions and data attributes (with separate read/write
    patterns). See the updated documentation of :mod:`lewis.adapters.stream`.
 
+ - The :class:`PV`-class has been extended to allow for meta data updates at runtime. A second
+   property can now be specified that returns a dictionary to update the PV's meta data such as
+   limits or alarm states.
+
 Bug fixes and other improvements
 --------------------------------
 


### PR DESCRIPTION
This fixes #158.

With this change it is now possible to supply PV with an additional argument `metadata_property` that returns a dict which updates PV metadata. Additionally, LimitViolationExceptions are now caught in PropertyExposingDriver so that the `check_limits` decorator can be used to enforce PV limits.