### PR TITLE
Fix disconnecting devices

### DIFF
--- a/lewis/adapters/__init__.py
+++ b/lewis/adapters/__init__.py
@@ -63,7 +63,7 @@ class Adapter(object):
 
     def start_server(self):
         """
-        This method should be re-implemented to start the infrastructure required for the
+        This method must be re-implemented to start the infrastructure required for the
         protocol in question. These startup operations are not supposed to be carried out on
         construction of the adapter in order to preserve control over when services are
         started during a run of a simulation.
@@ -75,11 +75,13 @@ class Adapter(object):
 
         .. seealso:: See :meth:`stop_server` for shutting down the adapter.
         """
-        pass
+        raise NotImplementedError(
+            'Adapters must implement start_server to construct and setup any servers or mechanism '
+            'required for network communication.')
 
     def stop_server(self):
         """
-        This method should be re-implemented to stop and tear down anything that has been setup
+        This method must be re-implemented to stop and tear down anything that has been setup
         in :meth:`start_server`. This method should close all connections to clients that have
         been established since the adapter has been started.
 
@@ -88,7 +90,9 @@ class Adapter(object):
             This method may be called multiple times over the lifetime of the Adapter, so it is
             important to make sure that this does not cause problems.
         """
-        pass
+        raise NotImplementedError(
+            'Adapters must implement stop_server to tear down anything that has been setup in '
+            'start_server.')
 
     @property
     def is_running(self):

--- a/lewis/adapters/__init__.py
+++ b/lewis/adapters/__init__.py
@@ -67,8 +67,38 @@ class Adapter(object):
         protocol in question. These startup operations are not supposed to be carried out on
         construction of the adapter in order to preserve control over when services are
         started during a run of a simulation.
+
+        .. note::
+
+            This method may be called multiple times over the lifetime of the Adapter, so it is
+            important to make sure that this does not cause problems.
+
+        .. seealso:: See :meth:`stop_server` for shutting down the adapter.
         """
         pass
+
+    def stop_server(self):
+        """
+        This method should be re-implemented to stop and tear down anything that has been setup
+        in :meth:`start_server`. This method should close all connections to clients that have
+        been established since the adapter has been started.
+
+        .. note::
+
+            This method may be called multiple times over the lifetime of the Adapter, so it is
+            important to make sure that this does not cause problems.
+        """
+        pass
+
+    @property
+    def is_running(self):
+        """
+        This property indicates whether the Adapter's server is running and listening. The result
+        of calls to :meth:`start_server` and :meth:`stop_server` should be reflected as expected.
+        """
+        raise NotImplementedError(
+            'Adapters must implement the is_running property to indicate whether '
+            'a server is currently running and listening for requests.')
 
     def handle(self, cycle_delay=0.1):
         """


### PR DESCRIPTION
This fixes #145.

`Adapter` now has a method `stop_server` in addition to `start_server`, as well as a `is_running` property which indicates the status of the adapter. Both in the EPICS and Stream cases, the entire server object is completely torn down in `stop_server`, so that existing connections are closed and new connections can not be made. As discussed in #144 and/or #145, there is a risk that the port is blocked by another process in the meantime, but currently all of that is the user's responsibility anyway so at the moment I do not see a big problem with this. Should we ever pursue the "simulators as a service" route, we have to re-think guarantees in that respect anyway.

The implementation of `Simulation` has been changed to make use of the new `Adapter` capabilities.

For testing the `simple_example` could be used:

Start a stream based device:
```
$ ./lewis.py -r localhost:10000 -k lewis.examples simple_device
```

Connect to it, make sure you get something from the device:
```
$ telnet localhost 9999
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
P
10
```

Disconnect the device:
```
./lewis-control.py simulation disconnect_device
```

The telnet session should close. For EPICS a `camonitor` should show the same behavior.

The suspend/resume problem has been transferred to a new issue #171.