### PR TITLE
Add release notes to generated documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Documentation contents:
    user_guide/index
    developer_guide/index
    api/index
+   release_notes/index
 
 
 Indices and tables

--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -1,0 +1,11 @@
+Release notes
+#############
+
+Here you can find release notes for all released versions of Lewis (release 1.0 was still
+called "Plankton").
+
+.. toctree::
+    :maxdepth: 1
+
+    release_1_0_1
+    release_1_0_0

--- a/docs/release_notes/release_1_0_0.rst
+++ b/docs/release_notes/release_1_0_0.rst
@@ -1,0 +1,23 @@
+Release 1.0
+===========
+
+The initial release of Lewis (at that point still plankton). These release notes have been
+compiled after the release as we were not keeping any release notes at that time.
+
+Features
+--------
+
+ - Cycle-based, deterministic device simulations based on finite state machines
+ - Control over the simulation's time granularity and speed (slow motion, fast forward)
+ - Simulation and device control via command line and via optional network service
+ - Two ready to use simulated devices using different protocols:
+
+    - ESS chopper abstraction (CHIC) using EPICS Channel Access
+    - Linkam T95 temperatur controller using TCP Stream protocol
+
+ - Docker image available on `docker hub`_ containing all dependencies
+ - Documentation in Markdown format for viewing in Github, both for users and developers
+ - Examples for implementing Stream protocol based devices
+
+.. _pcaspy: https://github.com/paulscherrerinstitute/pcaspy
+.. _docker hub: https://hub.docker.com/r/dmscid/lewis/

--- a/docs/release_notes/release_1_0_0.rst
+++ b/docs/release_notes/release_1_0_0.rst
@@ -13,7 +13,7 @@ Features
  - Two ready to use simulated devices using different protocols:
 
     - ESS chopper abstraction (CHIC) using EPICS Channel Access
-    - Linkam T95 temperatur controller using TCP Stream protocol
+    - Linkam T95 temperature controller using TCP Stream protocol
 
  - Docker image available on `docker hub`_ containing all dependencies
  - Documentation in Markdown format for viewing in Github, both for users and developers

--- a/docs/release_notes/release_1_0_1.rst
+++ b/docs/release_notes/release_1_0_1.rst
@@ -1,0 +1,33 @@
+Release 1.0.1
+=============
+
+This release is the first one under the name "Lewis". Its main purpose is to make a PyPI package
+available as well as online documentation under the new name.
+
+Nevertheless version 1.0.1 fixes some bugs and introduces a few new features that were originally
+scheduled for release 1.1 but had already been finished at the time of the release.
+
+New features
+------------
+
+ - It is now possible to obtain device interface documentation via the command line
+   and the control server, making it easier to communicate with unfamiliar devices.
+   Thanks to `David Michel`_ for requesting this feature.
+ - Lewis is now available as a `PyPI`_-package and can be installed via ``pip``.
+ - Documentation is now generated via Sphinx and has been made available online on `RTD`_.
+
+Bug fixes and other improvements
+--------------------------------
+
+ - The control server can now be bound to a hostname instead of an IP-address (very useful
+   for ``localhost`` in particular).
+ - pcaspy is now an optional requirement that has to be enabled explicitly in the requirements.txt
+   file or installation via ``pip install lewis[epics]``.
+ - Error messages displayed on the command line have been improved.
+ - A flake8 job has been added to the continuous integration pipeline to enforce Python
+   style guidelines in the codebase.
+
+
+.. _David Michel: https://github.com/dmichel76
+.. _PyPI: https://pypi.python.org/pypi/lewis
+.. _RTD: http://lewis.readthedocs.io/en/latest/

--- a/docs/release_notes/release_1_0_1.rst
+++ b/docs/release_notes/release_1_0_1.rst
@@ -12,8 +12,10 @@ New features
 
  - It is now possible to obtain device interface documentation via the command line
    and the control server, making it easier to communicate with unfamiliar devices.
+   For command line invocation there is a new flag: ``lewis -i linkam_t95``.
    Thanks to `David Michel`_ for requesting this feature.
- - Lewis is now available as a `PyPI`_-package and can be installed via ``pip``.
+
+ - Lewis is now available as a `PyPI`_-package and can be installed via ``pip install lewis``.
  - Documentation is now generated via Sphinx and has been made available online on `RTD`_.
 
 Bug fixes and other improvements
@@ -30,4 +32,4 @@ Bug fixes and other improvements
 
 .. _David Michel: https://github.com/dmichel76
 .. _PyPI: https://pypi.python.org/pypi/lewis
-.. _RTD: http://lewis.readthedocs.io/en/latest/
+.. _RTD: http://lewis.readthedocs.io/en/v1.0.1/

--- a/docs/release_notes/release_1_1_0.rst
+++ b/docs/release_notes/release_1_1_0.rst
@@ -10,7 +10,7 @@ New features
 
  - Exposing devices via TCP Stream has been made easier. It is now possible to define commands
    that expose lambda-functions, named functions and data attributes (with separate read/write
-   patterns).
+   patterns). See the updated documentation of :mod:`lewis.adapters.stream`.
 
 Bug fixes and other improvements
 --------------------------------

--- a/docs/release_notes/release_1_1_0.rst
+++ b/docs/release_notes/release_1_1_0.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+Release 1.1
+===========
+
+This release is work in progress.
+
+New features
+------------
+
+ - Exposing devices via TCP Stream has been made easier. It is now possible to define commands
+   that expose lambda-functions, named functions and data attributes (with separate read/write
+   patterns).
+
+Bug fixes and other improvements
+--------------------------------
+
+ - Virtually disconnecting devices via the control server now actually closes all network
+   connections and shuts down any running servers, making it impossible to re-connect to the
+   device in that state. Virtually re-connecting the device returns the behavior back to normal.


### PR DESCRIPTION
This fixes #168.

This adds release notes to the sphinx generated documentation so that it becomes part of the source and the online docs.

The current release has the `:orphan:` marker at the top to suppress a sphinx warning, because it is not included in the TOC yet, because it's work in progress and not yet intended to be seen by users.

After this has been merged, the current release document should be updated along with the code when changes are made.