### PR TITLE
Fix display of unserializable properties in control script

### DIFF
--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -41,16 +41,20 @@ def show_api(remote, object_name):
     methods = []
 
     for member_name in dir(obj):
-        if not member_name[0] in ('_', ':'):
-            member = getattr(obj, member_name)
-
-            if callable(member):
-                methods.append(member_name)
+        if member_name[0] not in ('_', ':') and member_name not in dir(type(obj)):
+            methods.append(member_name)
 
     print('Type: {}'.format(type(obj).__name__))
-    print('Properties:')
+
+    print('Properties (current values):')
     for prop in sorted(properties):
-        print('\t{}'.format(prop))
+        try:
+            current_value = getattr(obj, prop)
+        except Exception as e:
+            current_value = 'Not accessible: {}'.format(e.message)
+
+        print('\t{}\t{}'.format(prop, current_value))
+
     print('Methods:')
     for method in sorted(methods):
         print('\t{}'.format(method))

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -47,17 +47,18 @@ def show_api(remote, object_name):
     print('Type: {}'.format(type(obj).__name__))
 
     print('Properties (current values):')
+    maxlen = len(max(properties, key=len))
     for prop in sorted(properties):
         try:
             current_value = getattr(obj, prop)
         except Exception as e:
             current_value = 'Not accessible: {}'.format(e.message)
 
-        print('\t{}\t{}'.format(prop, current_value))
+        print('    {}    ({})'.format(prop.ljust(maxlen), current_value))
 
     print('Methods:')
     for method in sorted(methods):
-        print('\t{}'.format(method))
+        print('    {}'.format(method))
 
 
 def convert_type(value):


### PR DESCRIPTION
This fixes #174.

The interface is now correctly displayed also when certain members of the exposed object are not serializable. To make interaction easier, the current value of all device properties is printed, or a notice that it doesn't work and why.