### PR TITLE
Catch Ctrl-C and print friendly message

### DIFF
--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -111,7 +111,11 @@ def do_run_simulation(argument_list=None):
     simulation.cycle_delay = arguments.cycle_delay
     simulation.speed = arguments.speed
 
-    simulation.start()
+    try:
+        simulation.start()
+    except KeyboardInterrupt:
+        print('\nInterrupt received; shutting down. Goodbye, cruel world!')
+        simulation.log.critical('Simulation aborted by user interaction')
 
 
 def run_simulation(argument_list=None):
@@ -126,5 +130,3 @@ def run_simulation(argument_list=None):
         do_run_simulation(argument_list)
     except LewisException as e:
         print('\n'.join(('An error occurred:', e.message)))
-    except KeyboardInterrupt:
-        print('\nInterrupt received; shutting down. Goodbye, cruel world!')

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -64,7 +64,7 @@ parser.add_argument('adapter_args', nargs='*',
                     help='Arguments for the adapter.')
 
 
-def do_run_simulation(argument_list=None):
+def do_run_simulation(argument_list=None):  # noqa: C901
     arguments = parser.parse_args(argument_list or sys.argv[1:])
 
     if arguments.version:

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -126,3 +126,5 @@ def run_simulation(argument_list=None):
         do_run_simulation(argument_list)
     except LewisException as e:
         print('\n'.join(('An error occurred:', e.message)))
+    except KeyboardInterrupt:
+        print('\nInterrupt received; shutting down. Goodbye, cruel world!')


### PR DESCRIPTION
It always bugged me that you get a stack trace when you quit via CTRL-C.