### PR TITLE
Telnet Compatibility Option for TCP Stream

### DIFF
--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -216,8 +216,7 @@ class EpicsAdapter(Adapter):
     def __init__(self, device, arguments=None):
         super(EpicsAdapter, self).__init__(device, arguments)
 
-        if arguments is not None:
-            self._options = self._parseArguments(arguments)
+        self._options = self._parse_arguments(arguments or [])
 
         self._create_properties(self.pvs.values())
 
@@ -282,7 +281,7 @@ class EpicsAdapter(Adapter):
                                      + prop + '\' in device or interface.')
             setattr(type(self), prop, ForwardProperty('_device', prop, instance=self))
 
-    def _parseArguments(self, arguments):
+    def _parse_arguments(self, arguments):
         parser = ArgumentParser(description="Adapter to expose a device via EPICS")
         parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
         return parser.parse_args(arguments)

--- a/lewis/adapters/modbus.py
+++ b/lewis/adapters/modbus.py
@@ -567,9 +567,7 @@ class ModbusAdapter(Adapter):
     def __init__(self, device, arguments=None):
         super(ModbusAdapter, self).__init__(device, arguments)
 
-        if arguments is not None:
-            self._options = self._parse_arguments(arguments)
-
+        self._options = self._parse_arguments(arguments or [])
         self._server = None
 
     def _parse_arguments(self, arguments):

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -474,6 +474,10 @@ class StreamAdapter(Adapter):
 
         self._options = self._parse_arguments(arguments or [])
 
+        if self._options.telnet_mode:
+            self.in_terminator = '\r\n'
+            self.out_terminator = '\r\n'
+
         self._server = None
 
         self.bound_commands = self._bind_commands(self.commands)
@@ -522,6 +526,8 @@ class StreamAdapter(Adapter):
                             help='IP Address to bind and listen for connections on')
         parser.add_argument('-p', '--port', type=int, default=9999,
                             help='Port to listen for connections on')
+        parser.add_argument('-t', '--telnet-mode', action='store_true',
+                            help='Override terminators to be telnet compatible')
         return parser.parse_args(arguments)
 
     def _bind_commands(self, cmds):

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -472,8 +472,7 @@ class StreamAdapter(Adapter):
     def __init__(self, device, arguments=None):
         super(StreamAdapter, self).__init__(device, arguments)
 
-        if arguments is not None:
-            self._options = self._parseArguments(arguments)
+        self._options = self._parse_arguments(arguments or [])
 
         self._server = None
 
@@ -517,7 +516,7 @@ class StreamAdapter(Adapter):
     def is_running(self):
         return self._server is not None
 
-    def _parseArguments(self, arguments):
+    def _parse_arguments(self, arguments):
         parser = ArgumentParser(description='Adapter to expose a device via TCP Stream')
         parser.add_argument('-b', '--bind-address', default='0.0.0.0',
                             help='IP Address to bind and listen for connections on')


### PR DESCRIPTION
Fixes #180.

This adds a `-t` / `--telnet-mode` option to the TCP Stream adapter.

This option overrides both `in_terminator` and `out_terminator` to `\r\n`, in order to be compatible with what telnet expects. The purpose of this is to facilitate testing during development, without having to modify (and risk forgetting to change back) the terminators specified in the `Interface`.

Also pre-emptively fixed a logic error (that was never encountered) with the way all adapters parsed arguments.