### PR TITLE
Added command line tools help output to generated documentation

### DIFF
--- a/docs/user_guide/command_line_tools.rst
+++ b/docs/user_guide/command_line_tools.rst
@@ -1,0 +1,15 @@
+Command line tools
+==================
+
+This page documents the program usage for ``lewis`` and ``lewis-control``, the two command line
+tools provided as part of a Lewis installation.
+
+lewis
+-----
+
+.. automodule:: lewis.scripts.run
+
+lewis-control
+-------------
+
+.. automodule:: lewis.scripts.control

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -15,3 +15,4 @@ the remote control of device and simulation environment are introduced.
     adapter_specifics
     remote_access_devices
     remote_access_simulation
+    command_line_tools

--- a/lewis/scripts/__init__.py
+++ b/lewis/scripts/__init__.py
@@ -16,3 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
+
+from six import StringIO
+
+
+def get_usage_text(parser, indent=None):
+    """
+    This small helper function extracts the help information from an ArgumentParser instance
+    and indents the text by the number of spaces supplied in the indent-argument.
+
+    :param parser: ArgumentParser object.
+    :param indent: Number of spaces to put before each line or None.
+    :return: Formatted help string of the supplied parser.
+    """
+    usage_text = StringIO()
+    parser.print_help(usage_text)
+
+    usage_string = usage_text.getvalue()
+
+    if indent is None:
+        return usage_string
+
+    return '\n'.join([' ' * indent + line for line in usage_string.split('\n')])

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -23,6 +23,7 @@ import ast
 import sys
 
 from lewis.core.control_client import ControlClient
+from lewis.scripts import get_usage_text
 
 
 def list_objects(remote):
@@ -86,18 +87,36 @@ def call_method(remote, object_name, method, arguments):
 
 parser = argparse.ArgumentParser(
     description='A client to manipulate the simulated device remotely through a separate '
-                'channel. The simulation must be started with the --rpc-host option.')
-parser.add_argument('-r', '--rpc-host', default='127.0.0.1:10000',
-                    help='HOST:PORT string specifying control server to connect to.')
-parser.add_argument('-n', '--print-none', action='store_true',
-                    help='Print None return value.')
-parser.add_argument('object', nargs='?', default=None,
-                    help='Object to control. If left out, all objects are listed.')
-parser.add_argument('member', nargs='?', default=None,
-                    help='Object-member to access. If omitted, API of the object is listed.')
-parser.add_argument('arguments', nargs='*',
-                    help='Arguments to method call. For setting a property, '
-                         'supply the property value. ')
+                'channel. For this tool to be of any use, lewis must be invoked with the '
+                '-r/--rpc-host option.',
+    add_help=False, prog='lewis-control')
+
+positional_args = parser.add_argument_group('Positional arguments')
+positional_args.add_argument(
+    'object', nargs='?', default=None,
+    help='Object to control. If left out, all objects are listed.')
+positional_args.add_argument(
+    'member', nargs='?', default=None,
+    help='Object-member to access. If omitted, API of the object is listed.')
+positional_args.add_argument(
+    'arguments', nargs='*',
+    help='Arguments to method call. For setting a property, '
+         'supply the property value. ')
+
+optional_args = parser.add_argument_group('Optional arguments')
+optional_args.add_argument(
+    '-r', '--rpc-host', default='127.0.0.1:10000',
+    help='HOST:PORT string specifying control server to connect to.')
+optional_args.add_argument(
+    '-n', '--print-none', action='store_true',
+    help='By default, no output is generated if the remote function returns None. '
+         'Specifying this flag will force the client to print those None-values.')
+optional_args.add_argument(
+    '-h', '--h', action='help',
+    help='Shows this help message and exits.')
+
+__doc__ = 'To interact with the control server of a running simulation, use this script. ' \
+          'Usage:\n\n.. code-block:: none\n\n{}'.format(get_usage_text(parser, indent=4))
 
 
 def control_simulation(argument_list=None):

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -22,46 +22,87 @@ from lewis import __version__
 from lewis.core.devices import DeviceRegistry
 from lewis.core.simulation import Simulation
 from lewis.core.exceptions import LewisException
+from lewis.scripts import get_usage_text
 
 import argparse
 import os
 import sys
 
 parser = argparse.ArgumentParser(
-    description='Run a simulated device and expose it via a specified communication protocol.')
+    description='This script starts a simulated device that is exposed via the specified '
+                'communication protocol. Complete documentation of Lewis is available in '
+                'the online documentation: '
+                'https://lewis.readthedocs.io/en/v{}/'.format(__version__),
+    add_help=False, prog='lewis')
 
-parser.add_argument('-r', '--rpc-host', default=None,
-                    help='HOST:PORT format string for exposing the device via '
-                         'JSON-RPC over ZMQ.')
-parser.add_argument('-s', '--setup', default=None,
-                    help='Name of the setup to load.')
-parser.add_argument('-l', '--list-protocols',
-                    help='List available protocols for selected device.', action='store_true')
-parser.add_argument('-i', '--show-interface', action='store_true',
-                    help='Show command interface of device interface.')
-parser.add_argument('-p', '--protocol', default=None,
-                    help='Communication protocol to expose devices.')
-parser.add_argument('-c', '--cycle-delay', type=float, default=0.1,
-                    help='Approximate time to spend in each cycle of the simulation. '
-                         '0 for maximum simulation rate.')
-parser.add_argument('-e', '--speed', type=float, default=1.0,
-                    help='Simulation speed. The actually elapsed time between two cycles is '
-                         'multiplied with this speed to determine the simulated time.')
-parser.add_argument('-k', '--device-package', default='lewis.devices',
-                    help='Name of packages where devices are found.')
-parser.add_argument('-a', '--add-path', default=None,
-                    help='Path where the device package exists. Is added to the path.')
-parser.add_argument('-o', '--output-level', default='info',
-                    choices=['none', 'critical', 'error', 'warning', 'info', 'debug'],
-                    help='Level of detail for logging.')
-parser.add_argument('-v', '--version', action='store_true',
-                    help='Prints the version and exits.')
+positional_args = parser.add_argument_group('Positional arguments')
 
-parser.add_argument('device', nargs='?',
-                    help='Name of the device to simulate, '
-                         'omitting prints list of available devices.')
-parser.add_argument('adapter_args', nargs='*',
-                    help='Arguments for the adapter.')
+positional_args.add_argument(
+    'device', nargs='?',
+    help='Name of the device to simulate, omitting this argument prints out a list '
+         'of available devices.')
+positional_args.add_argument(
+    'adapter_args', nargs='*',
+    help='Arguments for the adapter. Must be separated from the device by a '
+         'double dash. Use lewis device -- -h to display parameter options.')
+
+device_args = parser.add_argument_group(
+    'Device related parameters',
+    'Parameters that influence the selected device, such as setup or protocol.')
+
+device_args.add_argument(
+    '-s', '--setup', default=None,
+    help='Name of the setup to load. If not provided, the default setup is selected. If there'
+         'is no default, a list of setups is printed.')
+device_args.add_argument(
+    '-p', '--protocol', default=None,
+    help='Communication protocol to expose device. Use the --l flag to see which protocols are '
+         'available for the selected device.')
+device_args.add_argument(
+    '-l', '--list-protocols', action='store_true',
+    help='List available protocols for selected device.')
+device_args.add_argument(
+    '-i', '--show-interface', action='store_true',
+    help='Show command interface of device interface.')
+device_args.add_argument(
+    '-k', '--device-package', default='lewis.devices',
+    help='Name of packages where devices are found.')
+device_args.add_argument(
+    '-a', '--add-path', default=None,
+    help='Path where the device package exists. Is added to the path.')
+
+simulation_args = parser.add_argument_group(
+    'Simulation related parameters',
+    'Parameters that influence the simulation itself, such as timing and speed.')
+
+simulation_args.add_argument(
+    '-c', '--cycle-delay', type=float, default=0.1,
+    help='Approximate time to spend in each cycle of the simulation. '
+         '0 for maximum simulation rate.')
+simulation_args.add_argument(
+    '-e', '--speed', type=float, default=1.0,
+    help='Simulation speed. The actually elapsed time between two cycles is '
+         'multiplied with this speed to determine the simulated time.')
+simulation_args.add_argument(
+    '-r', '--rpc-host', default=None,
+    help='HOST:PORT format string for exposing the device and the simulation via '
+         'JSON-RPC over ZMQ. Use lewis-control to access this service from the command line.')
+
+other_args = parser.add_argument_group('Other arguments')
+
+other_args.add_argument(
+    '-o', '--output-level', default='info',
+    choices=['none', 'critical', 'error', 'warning', 'info', 'debug'],
+    help='Level of detail for logging to stderr.')
+other_args.add_argument(
+    '-v', '--version', action='store_true',
+    help='Prints the version and exits.')
+other_args.add_argument(
+    '-h', '--h', action='help',
+    help='Shows this help message and exits.')
+
+__doc__ = 'This script is the main interaction point of the user with Lewis. The usage ' \
+          'is as follows:\n\n.. code-block:: none\n\n{}'.format(get_usage_text(parser, indent=4))
 
 
 def do_run_simulation(argument_list=None):  # noqa: C901


### PR DESCRIPTION
This fixes #176.

After trying different extensions to do automatic documentation of ArgumentParsers in sphinx, I decided to solve the problem without any extensions and just use the module docstring. I think if https://pythonhosted.org/sphinxcontrib-autoprogram/ has advanced one or two releases we could switch to that, as it produces quite nice lists, but 0.1.3 only works with Python 3 (which will be fixed in the next release) so at the moment it's not an option.

I also made the help a bit more detailed and tried putting the arguments into more logical categories than "positional" and "optional".