### PR TITLE
Added contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,56 @@
+Contributing to Lewis
+=====================
+
+Contributions to Lewis are always welcome and there are different ways of 
+contributing to the framework. We aim to respond to all communications within
+one working day.
+
+
+Reporting Issues
+----------------
+
+If you run into any issues or bugs while using Lewis, you can help us improve
+Lewis by opening an Issue here on GitHub. Please be sure to include enough 
+information to reproduce the issue.
+
+If you've already created a fix, you can also directly submit a Pull Request.
+
+
+Requesting Features
+-------------------
+
+If a feature you want is missing from Lewis, feel free to open an Issue here on
+GitHub to request it. Please describe the context and the expected behaviour in
+detail.
+
+If you've already implemented a new feature and would like to submit it, you
+can also directly submit a Pull Request.
+
+
+Submitting Pull Requests
+------------------------
+
+We are happy to accept contributed Pull Requests both from Forks and directly
+against this repository.
+
+If the Pull Request addresses any open Issues, please reference them with a 
+line that reads:
+
+    Closes #123.
+    
+Or similar, so that GitHub can link the Issue to the PR.
+
+The Pull Request description should detail the purpose of the Pull Request, and
+where appropriate should include some instructions on how to test the changes.
+
+Please ensure your Pull Request passes all integration tests and is able to be
+merged with master automatically.
+
+
+Submitting Devices
+------------------
+
+If you have a device you would like to contribute to the main repository, we
+are happy to accept these as a Pull Request as well. Please see the 
+documentation for details on how to write a device simulator.
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,32 +16,32 @@ here on GitHub. Please be sure to include enough information to reproduce the
 issue.
 
 If you've already created a fix, you can also directly
-`submit a Pull Request <#submitting-pull-request>`__.
+`submit a Pull Request <#submitting-pull-requests>`__.
 
 
 Requesting Features
 -------------------
 
-If a feature you want is missing from Lewis, feel free to open an Issue here on
-GitHub to request it. Please describe the context and the expected behaviour in
-detail.
+If a feature you want is missing from Lewis, feel free to
+`open an Issue <https://github.com/DMSC-Instrument-Data/lewis/issues/new>`__
+here on GitHub to request it. Please describe the context and the expected
+behaviour in detail.
 
 If you've already implemented a new feature and would like to submit it, you
-can also directly submit a Pull Request.
+can also directly `submit a Pull Request <#submitting-pull-requests>`__.
 
 
 Submitting Pull Requests
 ------------------------
 
-We are happy to accept contributed Pull Requests both from Forks and directly
-against this repository.
+We are happy to accept contributed Pull Requests from Forks.
 
-If the Pull Request addresses any open Issues, please reference them with a 
+If your Pull Request addresses any open Issues, please reference them with a
 line that reads:
 
     Closes #123.
     
-Or similar, so that GitHub can link the Issue to the PR.
+Or similar, so that GitHub can link the Issue to the Pull Request.
 
 The Pull Request description should detail the purpose of the Pull Request, and
 where appropriate should include some instructions on how to test the changes.
@@ -55,5 +55,5 @@ Submitting Devices
 
 If you have a device you would like to contribute to the main repository, we
 are happy to accept these as a Pull Request as well. Please see the 
-documentation for details on `how to write a device simulator <http://lewis.readthedocs.io/en/latest/developer_guide/writing_devices.html/>`__.
+documentation for details on `how to write a device simulator <http://lewis.readthedocs.io/en/latest/developer_guide/writing_devices.html>`__.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,10 +10,13 @@ Reporting Issues
 ----------------
 
 If you run into any issues or bugs while using Lewis, you can help us improve
-Lewis by opening an Issue here on GitHub. Please be sure to include enough 
-information to reproduce the issue.
+Lewis by
+`opening an Issue <https://github.com/DMSC-Instrument-Data/lewis/issues/new>`__
+here on GitHub. Please be sure to include enough information to reproduce the
+issue.
 
-If you've already created a fix, you can also directly submit a Pull Request.
+If you've already created a fix, you can also directly
+`submit a Pull Request <#submitting-pull-request>`__.
 
 
 Requesting Features
@@ -52,5 +55,5 @@ Submitting Devices
 
 If you have a device you would like to contribute to the main repository, we
 are happy to accept these as a Pull Request as well. Please see the 
-documentation for details on how to write a device simulator.
+documentation for details on `how to write a device simulator <http://lewis.readthedocs.io/en/latest/developer_guide/writing_devices.html/>`__.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,7 +40,7 @@ If your Pull Request addresses any open Issues, please reference them with a
 line that reads:
 
     Closes #123.
-    
+
 Or similar, so that GitHub can link the Issue to the Pull Request.
 
 The Pull Request description should detail the purpose of the Pull Request, and
@@ -54,6 +54,7 @@ Submitting Devices
 ------------------
 
 If you have a device you would like to contribute to the main repository, we
-are happy to accept these as a Pull Request as well. Please see the 
-documentation for details on `how to write a device simulator <http://lewis.readthedocs.io/en/latest/developer_guide/writing_devices.html>`__.
+are happy to accept these as a Pull Request as well. Please see the
+documentation for details on 
+`how to write a device simulator <http://lewis.readthedocs.io/en/latest/developer_guide/writing_devices.html>`__.
 

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -11,7 +11,7 @@ device from start to finish.
     :maxdepth: 2
 
     framework_details
-    contributing
+    writing_devices
 
 .. seealso::
 

--- a/docs/developer_guide/writing_devices.rst
+++ b/docs/developer_guide/writing_devices.rst
@@ -1,23 +1,11 @@
-Contributing to Lewis
-=====================
+Writing Device Simulators
+=========================
 
-How to contribute
------------------
+The following section describes how to write a new device simulator, what to 
+consider, and how to get the changes upstream.
 
-Contributions to Lewis are always welcome and there are different
-ways of contributing to the framework. Problems, bugs and questions
-should be opened as
-`issues <https://github.com/DMSC-Instrument-Data/lewis/issues>`__,
-this is a very good way of keeping track of how Lewis has developed
-over time and also for others to see if similar issues have been raised
-in the past.
-
-Another way to contribute is by writing a new device simulator. The
-following section describes how to do that, what to consider, and how to
-get the changes upstream.
-
-Writing a new device simulator
-------------------------------
+Getting Lewis Source Code
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Lewis framework provides all the infrastructure to run device
 simulations so that developing a new simulation requires little more


### PR DESCRIPTION
Closes #146.

Adds contribution guidelines to root directory and renames/adjusts previous device creation guide.