### PR TITLE
Fix control server/client issues

### DIFF
--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -13,6 +13,6 @@ Bug fixes and other improvements
 
  - Both :class:`~lewis.core.control_server.ControlServer` and
    :class:`~lewis.core.control_client.ControlClient` were subject to some improvements, most
-   notably a settable timeout for requests was added so that incomplete requests to not cause the
+   notably a settable timeout for requests was added so that incomplete requests do not cause the
    client to hang anymore. In ``lewis-control`` script, a new ``-t/--timeout`` argument was added
    to make use of that new functionality.

--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -1,0 +1,18 @@
+:orphan:
+
+Release 1.0.3
+=============
+
+This release is currently in progress.
+
+New features
+------------
+
+Bug fixes and other improvements
+--------------------------------
+
+ - Both :class:`~lewis.core.control_server.ControlServer` and
+   :class:`~lewis.core.control_client.ControlClient` were subject to some improvements, most
+   notably a settable timeout for requests was added so that incomplete requests to not cause the
+   client to hang anymore. In ``lewis-control`` script, a new ``-t/--timeout`` argument was added
+   to make use of that new functionality.

--- a/lewis/core/control_client.py
+++ b/lewis/core/control_client.py
@@ -26,7 +26,7 @@ This module provides client code for objects exposed via JSON-RPC over ZMQ.
     in the module :mod:`~lewis.core.control_server`.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import zmq
 import uuid
@@ -73,16 +73,30 @@ class ControlClient(object):
     of objects at the top level, a dictionary of named objects can be
     obtained via get_object_collection.
 
-    :param host: Host the control server is running on
-    :param port: Port on which the control server is listening
+    If a timeout is supplied, all underlying network operations time out
+    after the specified time (in milliseconds). The default is 1000 ms,
+    for no timeout specify ``None``.
+
+    :param host: Host the control server is running on.
+    :param port: Port on which the control server is listening.
+    :param timeout: Timeout in milliseconds for ZMQ operations.
     """
 
-    def __init__(self, host='127.0.0.1', port='10000'):
+    def __init__(self, host='127.0.0.1', port='10000', timeout=1000):
+        self.timeout = timeout if timeout is not None else -1
+
         self._socket = self._get_zmq_req_socket()
-        self._socket.connect('tcp://{0}:{1}'.format(host, port))
+
+        self._connection_string = 'tcp://{0}:{1}'.format(host, port)
+        self._socket.connect(self._connection_string)
 
     def _get_zmq_req_socket(self):
         context = zmq.Context()
+        context.setsockopt(zmq.REQ_CORRELATE, 1)
+        context.setsockopt(zmq.REQ_RELAXED, 1)
+        context.setsockopt(zmq.SNDTIMEO, self.timeout)
+        context.setsockopt(zmq.RCVTIMEO, self.timeout)
+        context.setsockopt(zmq.LINGER, 0)
         return context.socket(zmq.REQ)
 
     def json_rpc(self, method, *args):
@@ -98,14 +112,20 @@ class ControlClient(object):
         :return: JSON result and request id.
         """
         request_id = str(uuid.uuid4())
-        self._socket.send_json(
-            {'method': method,
-             'params': args,
-             'jsonrpc': '2.0',
-             'id': request_id
-             })
 
-        return self._socket.recv_json(), request_id
+        try:
+            self._socket.send_json(
+                {'method': method,
+                 'params': args,
+                 'jsonrpc': '2.0',
+                 'id': request_id
+                 })
+
+            return self._socket.recv_json(), request_id
+        except zmq.error.Again:
+            raise ProtocolException(
+                'The ZMQ connection to {} timed out after {:.2f}s.'.format(
+                    self._connection_string, self.timeout / 1000))
 
     def get_object(self, object_name=''):
         api, request_id = self.json_rpc(object_name + ':api')

--- a/lewis/core/control_client.py
+++ b/lewis/core/control_client.py
@@ -74,15 +74,14 @@ class ControlClient(object):
     obtained via get_object_collection.
 
     If a timeout is supplied, all underlying network operations time out
-    after the specified time (in milliseconds). The default is 1000 ms,
-    for no timeout specify ``None``.
+    after the specified time (in milliseconds), for no timeout specify ``None``.
 
     :param host: Host the control server is running on.
     :param port: Port on which the control server is listening.
     :param timeout: Timeout in milliseconds for ZMQ operations.
     """
 
-    def __init__(self, host='127.0.0.1', port='10000', timeout=1000):
+    def __init__(self, host='127.0.0.1', port='10000', timeout=3000):
         self.timeout = timeout if timeout is not None else -1
 
         self._socket = self._get_zmq_req_socket()

--- a/lewis/core/control_server.py
+++ b/lewis/core/control_server.py
@@ -137,6 +137,9 @@ class ExposedObject(object):
 
         self._function_map[name] = function
 
+    def _remove_function(self, name):
+        del self._function_map[name]
+
 
 class ExposedObjectCollection(ExposedObject):
     """
@@ -190,6 +193,22 @@ class ExposedObjectCollection(ExposedObject):
         for method_name in exposed_object:
             glue = '.' if not method_name.startswith(':') else ''
             self._add_function(name + glue + method_name, exposed_object[method_name])
+
+    def remove_object(self, name):
+        """
+        Remove the object exposed under that name. If no object is registered under the supplied
+        name, a RuntimeError is raised.
+
+        :param name: Name of object to be removed.
+        """
+        if name not in self._object_map:
+            raise RuntimeError('No object with name {} is registered.'.format(name))
+
+        for fn_name in list(self._function_map.keys()):
+            if fn_name.startswith(name + '.') or fn_name.startswith(name + ':'):
+                self._remove_function(fn_name)
+
+        del self._object_map[name]
 
     def get_objects(self):
         """Returns the names of the exposed objects."""

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -52,6 +52,8 @@ def show_api(remote, object_name):
     for prop in sorted(properties):
         try:
             current_value = getattr(obj, prop)
+        except ProtocolException:
+            raise
         except Exception as e:
             current_value = 'Not accessible: {}'.format(e)
 
@@ -108,7 +110,7 @@ optional_args.add_argument(
     '-r', '--rpc-host', default='127.0.0.1:10000',
     help='HOST:PORT string specifying control server to connect to.')
 optional_args.add_argument(
-    '-t', '--timeout', default='1000', type=int,
+    '-t', '--timeout', default=3000, type=int,
     help='Timeout after which the control client exits. Must be at least as long as '
          'one simulation cycle.')
 optional_args.add_argument(
@@ -141,4 +143,4 @@ def control_simulation(argument_list=None):
                 if response is not None or args.print_none:
                     print(response)
     except ProtocolException as e:
-        print('\n'.join(('An error occured:', str(e))))
+        print('\n'.join(('An error occurred:', str(e))))

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -37,17 +37,11 @@ def show_api(remote, object_name):
             'Object \'{}\' is not exposed by remote.'.format(object_name))
 
     obj = remote[object_name]
-
-    properties = list(obj._properties)
-    methods = []
-
-    for member_name in dir(obj):
-        if member_name[0] not in ('_', ':') and member_name not in dir(type(obj)):
-            methods.append(member_name)
-
     print('Type: {}'.format(type(obj).__name__))
 
     print('Properties (current values):')
+
+    properties = list(obj._properties)
     maxlen = len(max(properties, key=len))
     for prop in sorted(properties):
         try:
@@ -60,8 +54,12 @@ def show_api(remote, object_name):
         print('    {}    ({})'.format(prop.ljust(maxlen), current_value))
 
     print('Methods:')
-    for method in sorted(methods):
-        print('    {}'.format(method))
+    print('\n'.join(
+        sorted('    {}'.format(member) for member in dir(obj) if is_remote_method(obj, member))))
+
+
+def is_remote_method(obj, member):
+    return member[0] not in ('_', ':') and member not in dir(type(obj))
 
 
 def convert_type(value):

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -22,7 +22,7 @@ import argparse
 import ast
 import sys
 
-from lewis.core.control_client import ControlClient
+from lewis.core.control_client import ControlClient, ProtocolException
 from lewis.scripts import get_usage_text
 
 
@@ -108,6 +108,10 @@ optional_args.add_argument(
     '-r', '--rpc-host', default='127.0.0.1:10000',
     help='HOST:PORT string specifying control server to connect to.')
 optional_args.add_argument(
+    '-t', '--timeout', default='1000', type=int,
+    help='Timeout after which the control client exits. Must be at least as long as '
+         'one simulation cycle.')
+optional_args.add_argument(
     '-n', '--print-none', action='store_true',
     help='By default, no output is generated if the remote function returns None. '
          'Specifying this flag will force the client to print those None-values.')
@@ -122,15 +126,19 @@ __doc__ = 'To interact with the control server of a running simulation, use this
 def control_simulation(argument_list=None):
     args = parser.parse_args(argument_list or sys.argv[1:])
 
-    remote = ControlClient(*args.rpc_host.split(':')).get_object_collection()
+    try:
+        remote = ControlClient(*args.rpc_host.split(':'),
+                               timeout=args.timeout).get_object_collection()
 
-    if not args.object:
-        list_objects(remote)
-    else:
-        if not args.member:
-            show_api(remote, args.object)
+        if not args.object:
+            list_objects(remote)
         else:
-            response = call_method(remote, args.object, args.member, args.arguments)
+            if not args.member:
+                show_api(remote, args.object)
+            else:
+                response = call_method(remote, args.object, args.member, args.arguments)
 
-            if response is not None or args.print_none:
-                print(response)
+                if response is not None or args.print_none:
+                    print(response)
+    except ProtocolException as e:
+        print('\n'.join(('An error occured:', str(e))))

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -168,6 +168,25 @@ class TestExposedObjectCollection(unittest.TestCase):
         exposed_objects['container.test.getTest'](454, 43)
         obj.getTest.assert_called_once_with(454, 43)
 
+    def test_duplicate_name_raises(self):
+        exposed_objects = ExposedObjectCollection({})
+        exposed_objects.add_object(TestObject(), 'testObject')
+
+        self.assertRaises(RuntimeError, exposed_objects.add_object, TestObject(), 'testObject')
+
+    def test_remove_object(self):
+        exposed_objects = ExposedObjectCollection({})
+        own_functions_count = len(exposed_objects)
+
+        obj = TestObject()
+        exposed_objects.add_object(obj, 'testObject')
+
+        self.assertListEqual(exposed_objects.get_objects(), ['testObject'])
+        assertRaisesNothing(self, exposed_objects.remove_object, 'testObject')
+        self.assertEquals(len(exposed_objects), own_functions_count)
+
+        self.assertRaises(RuntimeError, exposed_objects.remove_object, 'does_not_exist')
+
 
 class TestControlServer(unittest.TestCase):
     @patch('zmq.Context')


### PR DESCRIPTION
This fixes #191.

It is now possible to remove exposed objects, although this is not used yet. But it will be important when we implement setup-switching (where the "old" device must be removed and the "new" device must be exposed). Properties are no longer called when the wrapper methods on the `ControlServer` are created. The connection of `ControlClient` times out after a user specified amount of time, the default is 1 second. Tests for the new behavior have been added, documentation (including release notes) has been updated.