### PR TITLE
Truncate multiline string properties in control.py

### DIFF
--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -48,7 +48,8 @@ def show_api(remote, object_name):
             raw_value = str(getattr(obj, prop))
             value_lines = raw_value.split('\n')
 
-            current_value = value_lines[0][40:] + (' [...]' if len(value_lines) > 1 else '')
+            current_value = value_lines[0][40:] + (
+                ' [...]' if len(value_lines) > 1 or len(value_lines[0]) > 40 else '')
         except ProtocolException:
             raise
         except Exception as e:

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -45,7 +45,10 @@ def show_api(remote, object_name):
     maxlen = len(max(properties, key=len))
     for prop in sorted(properties):
         try:
-            current_value = getattr(obj, prop)
+            raw_value = str(getattr(obj, prop))
+            value_lines = raw_value.split('\n')
+
+            current_value = value_lines[0] + (' [...]' if len(value_lines) > 1 else '')
         except ProtocolException:
             raise
         except Exception as e:

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -48,7 +48,7 @@ def show_api(remote, object_name):
             raw_value = str(getattr(obj, prop))
             value_lines = raw_value.split('\n')
 
-            current_value = value_lines[0] + (' [...]' if len(value_lines) > 1 else '')
+            current_value = value_lines[0][40:] + (' [...]' if len(value_lines) > 1 else '')
         except ProtocolException:
             raise
         except Exception as e:


### PR DESCRIPTION
This has no issue, but it is a fairly annoying bug. This change truncates multiline message and indicates further content by appending `[...]`.