### PR TITLE
Add unit tests for NotImplementedErrors

### DIFF
--- a/test/test_StateMachineDevice.py
+++ b/test/test_StateMachineDevice.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from mock import Mock, call
+from mock import Mock, call, patch
 
 from lewis.devices import StateMachineDevice
 from . import assertRaisesNothing
@@ -35,6 +35,17 @@ class MockStateMachineDevice(StateMachineDevice):
 
 
 class TestStateMachineDevice(unittest.TestCase):
+    def test_not_implemented_errors(self):
+        self.assertRaises(NotImplementedError, StateMachineDevice)
+
+        with patch('lewis.devices.StateMachineDevice._get_state_handlers',
+                   return_value={'test': Mock()}):
+            self.assertRaises(NotImplementedError, StateMachineDevice)
+
+            with patch('lewis.devices.StateMachineDevice._get_initial_state',
+                       return_value='test'):
+                self.assertRaises(NotImplementedError, StateMachineDevice)
+
     def test_init_calls_appropriate_methods(self):
         smd = MockStateMachineDevice()
 

--- a/test/test_StateMachineDevice.py
+++ b/test/test_StateMachineDevice.py
@@ -18,8 +18,9 @@
 # *********************************************************************
 
 import unittest
+import itertools
 
-from mock import Mock, call, patch
+from mock import Mock, MagicMock, call, patch
 
 from lewis.devices import StateMachineDevice
 from . import assertRaisesNothing
@@ -36,15 +37,24 @@ class MockStateMachineDevice(StateMachineDevice):
 
 class TestStateMachineDevice(unittest.TestCase):
     def test_not_implemented_errors(self):
+        # Construction of the base class should not be possible
         self.assertRaises(NotImplementedError, StateMachineDevice)
 
-        with patch('lewis.devices.StateMachineDevice._get_state_handlers',
-                   return_value={'test': Mock()}):
-            self.assertRaises(NotImplementedError, StateMachineDevice)
+        mandatory_methods = {
+            '_get_state_handlers': Mock(return_value={'test': MagicMock()}),
+            '_get_initial_state': Mock(return_value='test'),
+            '_get_transition_handlers': Mock(
+                return_value={('test', 'test'): Mock(return_value=True)})
+        }
 
-            with patch('lewis.devices.StateMachineDevice._get_initial_state',
-                       return_value='test'):
+        # If any of the mandatory methods is missing, a NotImplementedError must be raised
+        for methods in itertools.combinations(mandatory_methods.items(), 2):
+            with patch.multiple('lewis.devices.StateMachineDevice', **dict(methods)):
                 self.assertRaises(NotImplementedError, StateMachineDevice)
+
+        # If all are implemented, no exception should be raised
+        with patch.multiple('lewis.devices.StateMachineDevice', **mandatory_methods):
+            assertRaisesNothing(self, StateMachineDevice)
 
     def test_init_calls_appropriate_methods(self):
         smd = MockStateMachineDevice()

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import patch, call
+from mock import patch, call, Mock
 import inspect
 
 from lewis.adapters.stream import StreamAdapter
@@ -51,6 +51,14 @@ class TestAdapter(unittest.TestCase):
         adapter = DummyAdapter('foo')
 
         self.assertEqual(inspect.cleandoc(adapter.__doc__), adapter.documentation)
+
+    def test_not_implemented_errors(self):
+        adapter = Adapter(Mock())
+
+        self.assertRaises(NotImplementedError, adapter.start_server)
+        self.assertRaises(NotImplementedError, adapter.stop_server)
+        self.assertRaises(NotImplementedError, getattr, adapter, 'is_running')
+        assertRaisesNothing(self, adapter.handle, 0)
 
 
 class TestAdapterCollection(unittest.TestCase):


### PR DESCRIPTION
This has been bothering me for some time, these tests check that the `NotImplementedErrors` in the core framework are actually raised.