### PR TITLE
Clean up adapter documentation

### DIFF
--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -1,14 +1,11 @@
 Adapter API
 ===========
 
-The Adapter API consists of a general :mod:`~lewis.adapters`-module that defines a base class
-for all specific adapters. These specific adapters in turn define slightly different utilities
-for writing device interfaces.
+.. automodule:: lewis.adapters
 
 .. toctree::
     :maxdepth: 2
 
-    adapters/adapters
     adapters/epics
     adapters/modbus
     adapters/stream

--- a/docs/api/adapters/adapters.rst
+++ b/docs/api/adapters/adapters.rst
@@ -1,5 +1,0 @@
-The Adapters Module
--------------------
-
-.. automodule:: lewis.adapters
-    :members:

--- a/docs/api/adapters/epics.rst
+++ b/docs/api/adapters/epics.rst
@@ -1,4 +1,4 @@
-The EPICS-Adapter
+The EPICS Adapter
 -----------------
 
 .. automodule:: lewis.adapters.epics

--- a/docs/api/adapters/stream.rst
+++ b/docs/api/adapters/stream.rst
@@ -1,4 +1,4 @@
-The Stream-Adapter
+The Stream Adapter
 ------------------
 
 .. automodule:: lewis.adapters.stream

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -7,13 +7,14 @@ state machine, control server and client infrastructure and some utilities.
 .. toctree::
     :maxdepth: 2
 
+    core/adapters
+    core/approaches
+    core/control_client
+    core/control_server
+    core/devices
     core/exceptions
     core/logging
     core/processor
-    core/statemachine
-    core/approaches
-    core/control_server
-    core/control_client
-    core/devices
     core/simulation
+    core/statemachine
     core/utils

--- a/docs/api/core/adapters.rst
+++ b/docs/api/core/adapters.rst
@@ -1,0 +1,5 @@
+Adapters Module
+---------------
+
+.. automodule:: lewis.core.adapters
+    :members:

--- a/lewis/adapters/__init__.py
+++ b/lewis/adapters/__init__.py
@@ -18,7 +18,7 @@
 # *********************************************************************
 
 """
-The core Adapter API is located in :mod:`lewis.core.adapters`. This module on the contains
+The core Adapter API is located in :mod:`lewis.core.adapters`. This package on the contains
 concrete implementations of :class:`~lewis.core.adapters.Adapter` in its submodules, along with
 specific tools for each adapter.
 """

--- a/lewis/adapters/__init__.py
+++ b/lewis/adapters/__init__.py
@@ -18,6 +18,7 @@
 # *********************************************************************
 
 """
-This module contains concrete implementations of :class:`~lewis.core.adapters.Adapter` in its
-submodules.
+The core Adapter API is located in :mod:`lewis.core.adapters`. This module on the contains
+concrete implementations of :class:`~lewis.core.adapters.Adapter` in its submodules, along with
+specific tools for each adapter.
 """

--- a/lewis/adapters/__init__.py
+++ b/lewis/adapters/__init__.py
@@ -18,7 +18,7 @@
 # *********************************************************************
 
 """
-The core Adapter API is located in :mod:`lewis.core.adapters`. This package on the contains
-concrete implementations of :class:`~lewis.core.adapters.Adapter` in its submodules, along with
+The core Adapter API is located in :mod:`lewis.core.adapters`. This package contains concrete
+implementations of :class:`~lewis.core.adapters.Adapter` in its submodules, along with
 specific tools for each adapter.
 """


### PR DESCRIPTION
After moving adapters to `core.adapters`, we forgot to also modify the documentation. This fixes the documentation, plus the core APIs are now alphabetically ordered which is easier to scan through.