### PR TITLE
Decouple adapter construction and device binding

### DIFF
--- a/docs/developer_guide/writing_devices.rst
+++ b/docs/developer_guide/writing_devices.rst
@@ -242,17 +242,17 @@ According to the specifications above, the commands are defined like this:
         out_terminator = '\r\n'
 
         def get_status(self):
-            return self._device.state
+            return self.device.state
 
         def get_position(self):
-            return self._device.position
+            return self.device.position
 
         def get_target(self):
-            return self._device.target
+            return self.device.target
 
         def set_target(self, new_target):
             try:
-                self._device.target = new_target
+                self.device.target = new_target
                 return 'T={}'.format(new_target)
             except RuntimeError:
                 return 'err: not idle'
@@ -276,7 +276,7 @@ is the case for the ``stop``-command.
 You may have noticed that ``stop`` is not a method of the interface.
 :class:`~lewis.adapters.stream.StreamAdapter` tries to resolve the supplied method
 names in multiple ways. First it checks its own members, then it checks the members of the
-device it owns (accessible in the interface via the ``_device``-member)
+device it owns (accessible in the interface via the ``device``-member)
 and adds forwarders to itself if possible. If the method name can not be
 found in either the device or the adapter, an error is produced, which
 minimizes the likelihood of typos. The definitions in the interface

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -296,6 +296,10 @@ class EpicsAdapter(Adapter):
         self._bound_pvs = {}
 
     def _bind_device(self):
+        """
+        This method is re-implemented from :class:`~lewis.core.adapters.Adapter`. It uses
+        :meth:`_bind_properties` to generate a dict of bound PVs.
+        """
         self._bound_pvs = self._bind_properties(self.pvs)
 
     def _bind_properties(self, pvs):

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -279,7 +279,6 @@ class EpicsAdapter(Adapter):
     via EPICS might involve writing a value to a PV, whereas other protocols may
     offer an RPC-way of achieving the same thing.
 
-    :param device: The device that is exposed by the adapter.
     :param arguments: Command line arguments to parse.
     """
     protocol = 'epics'

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -70,8 +70,8 @@ class PV(object):
             @property
             def example_meta(self):
                 return {
-                    'lolim': self._device._example_low_limit,
-                    'hilim': self._device._example_high_limit,
+                    'lolim': self.device._example_low_limit,
+                    'hilim': self.device._example_high_limit,
                 }
 
     The PV infos are then updated together with the value, determined by ``poll_interval``.
@@ -261,7 +261,7 @@ class EpicsAdapter(Adapter):
             @stop.setter
             def stop(self, value):
                 if value == 1:
-                    self._device.halt()
+                    self.device.halt()
 
     Even though the device does *not* have a property called ``stop`` (but a method called
     ``halt``), issuing the command
@@ -330,8 +330,8 @@ class EpicsAdapter(Adapter):
         if prop in dir(self):
             return self
 
-        if prop in dir(self._device):
-            return self._device
+        if prop in dir(self.device):
+            return self.device
 
         raise AttributeError('Can not find property \''
                              + prop + '\' in device or interface.')

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -285,14 +285,18 @@ class EpicsAdapter(Adapter):
     protocol = 'epics'
     pvs = None
 
-    def __init__(self, device, arguments=None):
-        super(EpicsAdapter, self).__init__(device, arguments)
+    def __init__(self, arguments=None):
+        super(EpicsAdapter, self).__init__(arguments)
 
         self._options = self._parse_arguments(arguments or [])
-        self._bound_pvs = self._bind_properties(self.pvs)
 
         self._server = None
         self._driver = None
+
+        self._bound_pvs = {}
+
+    def _bind_device(self):
+        self._bound_pvs = self._bind_properties(self.pvs)
 
     def _bind_properties(self, pvs):
         """

--- a/lewis/adapters/modbus.py
+++ b/lewis/adapters/modbus.py
@@ -585,8 +585,8 @@ class ModbusAdapter(Adapter):
     ir = None
     hr = None
 
-    def __init__(self, device, arguments=None):
-        super(ModbusAdapter, self).__init__(device, arguments)
+    def __init__(self, arguments=None):
+        super(ModbusAdapter, self).__init__(arguments)
 
         self._options = self._parse_arguments(arguments or [])
         self._server = None

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -445,10 +445,10 @@ class StreamAdapter(Adapter):
             ]
 
             def set_speed(self, new_speed):
-                self._device.speed = new_speed
+                self.device.speed = new_speed
 
             def get_speed(self):
-                return self._device.speed
+                return self.device.speed
 
     The interface has two commands, ``S?`` to return the speed and ``S=10`` to set the speed
     to an integer value.
@@ -496,7 +496,7 @@ class StreamAdapter(Adapter):
         bound_commands = []
 
         for cmd in cmds:
-            bound = cmd.bind(self) or cmd.bind(self._device) or None
+            bound = cmd.bind(self) or cmd.bind(self.device) or None
 
             if bound is None:
                 raise RuntimeError(

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -454,12 +454,12 @@ class StreamAdapter(Adapter):
     to an integer value.
 
     As in the :class:`lewis.adapters.epics.EpicsAdapter`, it does not matter whether the
-    wrapped method is a part of the device or of the interface, this is handled automatically.
+    wrapped method is a part of the device or of the interface, this is handled automatically when
+    a new device is assigned to the ``device``-property.
 
     In addition, the :meth:`handle_error`-method can be overridden. It is called when an exception
     is raised while handling commands.
 
-    :param device: The exposed device.
     :param arguments: Command line arguments.
     """
     protocol = 'stream'
@@ -469,8 +469,8 @@ class StreamAdapter(Adapter):
 
     commands = None
 
-    def __init__(self, device, arguments=None):
-        super(StreamAdapter, self).__init__(device, arguments)
+    def __init__(self, arguments=None):
+        super(StreamAdapter, self).__init__(arguments)
 
         self._options = self._parse_arguments(arguments or [])
 
@@ -479,7 +479,9 @@ class StreamAdapter(Adapter):
             self.out_terminator = '\r\n'
 
         self._server = None
+        self._bound_commands = []
 
+    def _bind_device(self):
         self.bound_commands = self._bind_commands(self.commands)
 
     @property

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -49,14 +49,48 @@ class Adapter(object):
     implementations of existing adapters (:class:`~lewis.adapters.epics.EpicsAdapter`,
     :class:`~lewis.adapters.stream.StreamAdapter`),to get some examples.
 
-    :param device: Device that is supposed to be exposed. Available as ``_device``.
+    In principle, an adapter can exist on its own, but it only really becomes useful when a device
+    is bound to it. To do this, assign an object derived from
+    :class:`lewis.core.devices.DeviceBase` to the ``device``-property. Sub-classes have to
+    implement :meth:`_bind_device` to achieve actual binding behavior.
+
     :param arguments: Command line arguments to the adapter, currently ignored.
     """
     protocol = None
 
-    def __init__(self, device, arguments=None):
+    def __init__(self, arguments=None):
         super(Adapter, self).__init__()
-        self._device = device
+        self._device = None
+
+    @property
+    def device(self):
+        """
+        The device property contains the device-object exposed by the adapter.
+
+        The property can be set from the outside, at that point the adapter will
+        call :meth:`_bind_device` (which is implemented in each adapter sub-class)
+        and thus re-bind its commands etc. to call the new device.
+        """
+        return self._device
+
+    @device.setter
+    def device(self, new_device):
+        self._device = new_device
+        self._bind_device()
+
+    def _bind_device(self):
+        """
+        This method is called in the setter of the ``device`` property after the device
+        has been set. Implementations should do whatever is necessary to actually expose
+        any methods that are part of the device and not the interface.
+
+        .. seealso:
+
+            Some concrete implementations in the framework:
+             - :meth:`lewis.adapters.epics.EpicsAdapter._bind_device`
+             - :meth:`lewis.adapters.stream.StreamAdapter._bind_device`
+        """
+        pass
 
     @property
     def documentation(self):

--- a/lewis/devices/chopper/interfaces/epics_interface.py
+++ b/lewis/devices/chopper/interfaces/epics_interface.py
@@ -108,7 +108,7 @@ class ChopperEpicsInterface(EpicsAdapter):
     def execute_command(self, value):
         command = self._commands.get(value)
 
-        getattr(self._device, command)()
+        getattr(self.device, command)()
         self._last_command = command
 
     @property

--- a/lewis/devices/linkam_t95/interfaces/stream_interface.py
+++ b/lewis/devices/linkam_t95/interfaces/stream_interface.py
@@ -56,7 +56,7 @@ class LinkamT95StreamInterface(StreamAdapter):
         """
 
         # "The first command sent must be a 'T' command" from T95 manual
-        self._device.serial_command_mode = True
+        self.device.serial_command_mode = True
 
         Tarray = [0x80] * 10
 
@@ -66,21 +66,21 @@ class LinkamT95StreamInterface(StreamAdapter):
             'heat': 0x10,
             'cool': 0x20,
             'hold': 0x30,
-        }.get(self._device._csm.state, 0x01)
+        }.get(self.device._csm.state, 0x01)
 
-        if Tarray[0] == 0x30 and self._device.hold_commanded:
+        if Tarray[0] == 0x30 and self.device.hold_commanded:
             Tarray[0] = 0x50
 
         # Error status byte (EB1)
-        if self._device.pump_overspeed:
+        if self.device.pump_overspeed:
             Tarray[1] |= 0x01
         # TODO: Add support for other error conditions?
 
         # Pump status byte (PB1)
-        Tarray[2] = 0x80 + self._device.pump_speed
+        Tarray[2] = 0x80 + self.device.pump_speed
 
         # Temperature
-        Tarray[6:10] = [ord(x) for x in "%04x" % (int(self._device.temperature * 10) & 0xFFFF)]
+        Tarray[6:10] = [ord(x) for x in "%04x" % (int(self.device.temperature * 10) & 0xFFFF)]
 
         return ''.join(chr(c) for c in Tarray)
 
@@ -97,7 +97,7 @@ class LinkamT95StreamInterface(StreamAdapter):
         # TODO: Is not having leading zeroes / 4 digits an error?
         rate = int(param)
         if 1 <= rate <= 15000:
-            self._device.temperature_rate = rate / 100.0
+            self.device.temperature_rate = rate / 100.0
         return ""
 
     def set_limit(self, param):
@@ -112,7 +112,7 @@ class LinkamT95StreamInterface(StreamAdapter):
         # TODO: Is not having leading zeroes / 4 digits an error?
         limit = int(param)
         if -2000 <= limit <= 6000:
-            self._device.temperature_limit = limit / 10.0
+            self.device.temperature_limit = limit / 10.0
         return ""
 
     def start(self):
@@ -124,7 +124,7 @@ class LinkamT95StreamInterface(StreamAdapter):
 
         :return: Empty string.
         """
-        self._device.start_commanded = True
+        self.device.start_commanded = True
         return ""
 
     def stop(self):
@@ -135,7 +135,7 @@ class LinkamT95StreamInterface(StreamAdapter):
 
         :return: Empty string.
         """
-        self._device.stop_commanded = True
+        self.device.stop_commanded = True
         return ""
 
     def hold(self):
@@ -146,7 +146,7 @@ class LinkamT95StreamInterface(StreamAdapter):
 
         :return: Empty string.
         """
-        self._device.hold_commanded = True
+        self.device.hold_commanded = True
         return ""
 
     def heat(self):
@@ -156,7 +156,7 @@ class LinkamT95StreamInterface(StreamAdapter):
         :return: Empty string.
         """
         # TODO: Is this really all it does?
-        self._device.hold_commanded = False
+        self.device.hold_commanded = False
         return ""
 
     def cool(self):
@@ -166,7 +166,7 @@ class LinkamT95StreamInterface(StreamAdapter):
         :return: Empty string.
         """
         # TODO: Is this really all it does?
-        self._device.hold_commanded = False
+        self.device.hold_commanded = False
         return ""
 
     def pump_command(self, param):
@@ -181,10 +181,10 @@ class LinkamT95StreamInterface(StreamAdapter):
         lookup = [c for c in "0123456789:;<=>?@ABCDEFGHIJKLMN"]
 
         if param == "a0":
-            self._device.pump_manual_mode = False
+            self.device.pump_manual_mode = False
         elif param == "m0":
-            self._device.pump_manual_mode = True
+            self.device.pump_manual_mode = True
         elif param in lookup:
-            self._device.manual_target_speed = lookup.index(param)
+            self.device.manual_target_speed = lookup.index(param)
 
         return ""

--- a/lewis/examples/example_motor/__init__.py
+++ b/lewis/examples/example_motor/__init__.py
@@ -111,15 +111,15 @@ class ExampleMotorStreamInterface(StreamAdapter):
 
     def get_status(self):
         """Returns the status of the device, which is one of 'idle' or 'moving'."""
-        return self._device.state
+        return self.device.state
 
     def get_position(self):
         """Returns the current position in mm."""
-        return self._device.position
+        return self.device.position
 
     def get_target(self):
         """Returns the current target in mm."""
-        return self._device.target
+        return self.device.target
 
     def set_target(self, new_target):
         """
@@ -127,7 +127,7 @@ class ExampleMotorStreamInterface(StreamAdapter):
         the interval [0, 250] or the motor is already moving, an error is returned, otherwise
         the new target is returned."""
         try:
-            self._device.target = new_target
+            self.device.target = new_target
             return 'T={}'.format(new_target)
         except RuntimeError:
             return 'err: not idle'

--- a/lewis/examples/simple_device/__init__.py
+++ b/lewis/examples/simple_device/__init__.py
@@ -59,11 +59,11 @@ class VerySimpleInterface(StreamAdapter):
 
     def get_param(self):
         """Returns the device parameter."""
-        return self._device.param
+        return self.device.param
 
     def set_param(self, new_param):
         """Set the device parameter, does not return anything."""
-        self._device.param = new_param
+        self.device.param = new_param
 
     def handle_error(self, request, error):
         return 'An error occurred: ' + repr(error)

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -141,8 +141,9 @@ def do_run_simulation(argument_list=None):  # noqa: C901
         return
 
     device = device_builder.create_device(arguments.setup)
-    interface = device_builder.create_interface(arguments.protocol,
-                                                device=device, arguments=arguments.adapter_args)
+    interface = device_builder.create_interface(
+        arguments.protocol, arguments=arguments.adapter_args)
+    interface.device = device
 
     if arguments.show_interface:
         print(interface.documentation)

--- a/test/test_SimulatedLinkamT95.py
+++ b/test/test_SimulatedLinkamT95.py
@@ -39,8 +39,9 @@ class TestSimulatedLinkamT95(unittest.TestCase):
             self, SimulatedLinkamT95, override_transitions={('init', 'stopped'): lambda: True})
 
     def test_default_status(self):
-        linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam = LinkamT95StreamInterface()
+        linkam.device = SimulatedLinkamT95()
+
         status_bytes = linkam.get_status()
 
         self.assertEqual(len(status_bytes), 10)     # Byte array should always be 10 bytes
@@ -51,8 +52,11 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         self.assertEqual(status_bytes[6:10], '00f0')  # Starting temperature 24C
 
     def test_simple_heat(self):
+        linkam = LinkamT95StreamInterface()
+
         linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam.device = linkam_device
+
         linkam_device.process()  # Initialize
 
         # Issue T command to get into stopped state
@@ -83,8 +87,10 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         self.assertEqual(status_bytes[6:10], '01b8')    # Temp == 44.0 C
 
     def test_simple_cool(self):
+        linkam = LinkamT95StreamInterface()
         linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam.device = linkam_device
+
         linkam_device.process()  # Initialize
 
         # Issue T command to get into stopped state
@@ -115,8 +121,10 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         self.assertEqual(status_bytes[6:10], '0028')    # Temp == 4.0 C
 
     def test_error_flag_overcool(self):
+        linkam = LinkamT95StreamInterface()
         linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam.device = linkam_device
+
         linkam_device.process()  # Initialize
 
         # Issue T command to get into stopped state
@@ -139,8 +147,10 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         self.assertTrue(ord(status_bytes[1]) & 0x01)
 
     def test_stop_command(self):
+        linkam = LinkamT95StreamInterface()
         linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam.device = linkam_device
+
         linkam_device.process()  # Initialize
 
         # Issue T command to get into stopped state
@@ -163,8 +173,10 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         self.assertEqual(ord(status_bytes[0]), 0x01)
 
     def test_hold_and_resume(self):
+        linkam = LinkamT95StreamInterface()
         linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam.device = linkam_device
+
         linkam_device.process()  # Initialize
 
         # Issue T command to get into stopped state
@@ -215,8 +227,10 @@ class TestSimulatedLinkamT95(unittest.TestCase):
         self.assertEqual(status_bytes[0], '\x30')  # Auto-holding at limit
 
     def test_pump_command(self):
+        linkam = LinkamT95StreamInterface()
         linkam_device = SimulatedLinkamT95()
-        linkam = LinkamT95StreamInterface(linkam_device, None)
+        linkam.device = linkam_device
+
         linkam_device.process()  # Initialize
 
         # Issue T command to get into stopped state

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -53,12 +53,28 @@ class TestAdapter(unittest.TestCase):
         self.assertEqual(inspect.cleandoc(adapter.__doc__), adapter.documentation)
 
     def test_not_implemented_errors(self):
-        adapter = Adapter(Mock())
+        adapter = Adapter()
 
         self.assertRaises(NotImplementedError, adapter.start_server)
         self.assertRaises(NotImplementedError, adapter.stop_server)
         self.assertRaises(NotImplementedError, getattr, adapter, 'is_running')
         assertRaisesNothing(self, adapter.handle, 0)
+
+    def test_device_property(self):
+        adapter = Adapter()
+        mock_device = Mock()
+
+        # Make sure that the default implementation works (for adapters that do
+        # not have binding behavior).
+        adapter.device = mock_device
+        self.assertEqual(adapter.device, mock_device)
+
+        with patch('lewis.core.adapters.Adapter._bind_device') as bind_mock:
+            adapter.device = None
+
+            bind_mock.assert_called_once()
+            self.assertEqual(adapter.device, None)
+
 
 
 class TestAdapterCollection(unittest.TestCase):

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -76,7 +76,6 @@ class TestAdapter(unittest.TestCase):
             self.assertEqual(adapter.device, None)
 
 
-
 class TestAdapterCollection(unittest.TestCase):
     def test_add_adapter(self):
         collection = AdapterCollection()

--- a/test/test_core_devices.py
+++ b/test/test_core_devices.py
@@ -104,8 +104,6 @@ class TestDeviceBuilderSimpleModule(unittest.TestCase):
     def test_create_interface(self):
         builder = DeviceBuilder(self.module)
 
-        device = builder.create_device()
-
         self.assertIsInstance(builder.create_interface(), self.module.DummyAdapter)
         self.assertIsInstance(
             builder.create_interface('dummy'), self.module.DummyAdapter)

--- a/test/test_core_devices.py
+++ b/test/test_core_devices.py
@@ -106,9 +106,9 @@ class TestDeviceBuilderSimpleModule(unittest.TestCase):
 
         device = builder.create_device()
 
-        self.assertIsInstance(builder.create_interface(device=device), self.module.DummyAdapter)
+        self.assertIsInstance(builder.create_interface(), self.module.DummyAdapter)
         self.assertIsInstance(
-            builder.create_interface('dummy', device=device), self.module.DummyAdapter)
+            builder.create_interface('dummy'), self.module.DummyAdapter)
 
         self.assertRaises(LewisException, builder.create_interface, 'invalid_protocol')
 


### PR DESCRIPTION
This fixes #207.

With these changes, `device` is no longer an argument of `Adpater.__init__`. This makes it possible to construct an adapter without the need of having a device object available at exactly that point. As a side-effect, it is now also much easier to "re-bind" another device, e.g. to swap out the device at runtime completely seamlessly (from the adapter's point of view). This will make it much easier to implemented #98.

Also, `device` is now a "proper" member of `Adapter`, making it less awkward to access the device when writing an interface. The internal `_device` still works, but maybe we should add a recommendation to the release notes that `device` is now available and should be used instead.

The user facing documentation has been updated.