### PR TITLE
Allow switching setups at runtime

### DIFF
--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -20,8 +20,6 @@ New features
 
       $ lewis-control simulation switch_setup new_setup
 
-   The simulation cycles and runtime are reset.
-
  - It has been made easier to deposit devices in an external module while maintaining control over
    compatibility with the rest of the Lewis-framework. Lewis now checks for a version specification
    in each device module against the framework version before obtaining devices, adapters and

--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -8,6 +8,20 @@ This release is currently in progress.
 New features
 ------------
 
+ - The device setup can be changed at runtime through the control server. It is not possible to switch to another device, only setups of the same device can be used. To query available setups:
+
+   .. ::
+
+      $ lewis-control simulation setups
+
+   Then, to actually activate the new setup, assuming it is called ``new_setup``:
+
+   .. ::
+
+      $ lewis-control simulation switch_setup new_setup
+
+   The simulation cycles and runtime are reset.
+
  - It has been made easier to deposit devices in an external module while maintaining control over
    compatibility with the rest of the Lewis-framework. Lewis now checks for a version specification
    in each device module against the framework version before obtaining devices, adapters and

--- a/docs/user_guide/remote_access_devices.rst
+++ b/docs/user_guide/remote_access_devices.rst
@@ -72,7 +72,7 @@ It is then possible to switch the setup to one from the list, assuming it is cal
 
     $ lewis-control simulation switch_setup new_setup
 
-Note that the cycle count and the elapsed simulation runtime are reset.
+The setup switching process is logged.
 
 .. _remote-interface-access:
 

--- a/docs/user_guide/remote_access_devices.rst
+++ b/docs/user_guide/remote_access_devices.rst
@@ -59,6 +59,21 @@ itself, so that it is generic to all devices:
 
     $ lewis-control simulation set_device_parameters "{'target_speed': 1, 'target_phase': 20}"
 
+Another case of device-related access to the simulation is switching the setup. To obtain a
+list of available setups, the following command is available:
+
+::
+
+    $ lewis-control simulation setups
+
+It is then possible to switch the setup to one from the list, assuming it is called ``new_setup``:
+
+::
+
+    $ lewis-control simulation switch_setup new_setup
+
+Note that the cycle count and the elapsed simulation runtime are reset.
+
 .. _remote-interface-access:
 
 Accessing the Device Communication Interface

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -123,8 +123,7 @@ class Simulation(object):
     def switch_setup(self, new_setup):
         """
         This method switches the setup, which means that it replaces the currently
-        simulated device with a new device, as defined by the setup. This resets
-        the timers that keep track of the simulation.
+        simulated device with a new device, as defined by the setup.
 
         If any error occurs during setup switching it is logged and re-raised.
 
@@ -132,17 +131,13 @@ class Simulation(object):
         """
         try:
             self._device = self._device_builder.create_device(new_setup)
-            self._reset_timers()
             self._adapters.device = self._device
+            self.log.info('Switched setup to \'%s\'', new_setup)
         except Exception as e:
             self.log.error(
                 'Caught an error while trying to switch setups. Setup not switched, '
                 'simulation continues: %s', e)
             raise
-
-    def _reset_timers(self):
-        self._cycles = 0  # Number of cycles processed
-        self._runtime = 0.0  # Total simulation time processed
 
     def start(self):
         """

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -152,6 +152,7 @@ def do_run_simulation(argument_list=None):  # noqa: C901
     simulation = Simulation(
         device=device,
         adapter=interface,
+        device_builder=device_builder,
         control_server=arguments.rpc_host)
 
     simulation.cycle_delay = arguments.cycle_delay

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import patch, call, Mock
+from mock import patch, call, Mock, MagicMock
 import inspect
 
 from lewis.adapters.stream import StreamAdapter
@@ -92,6 +92,33 @@ class TestAdapterCollection(unittest.TestCase):
         self.assertSetEqual(set(collection.protocols), {'foo', 'bar'})
 
         self.assertRaises(RuntimeError, collection.add_adapter, DummyAdapter('bar'))
+
+    def test_set_device(self):
+        mock_adapter1 = MagicMock()
+        mock_adapter2 = MagicMock()
+
+        collection = AdapterCollection(mock_adapter1, mock_adapter2)
+        collection.device = 'foo'
+
+        self.assertEqual(mock_adapter1.device, 'foo')
+        self.assertEqual(mock_adapter1.device, 'foo')
+
+        mock_adapter3 = MagicMock()
+        mock_adapter3.device = 'other'
+
+        collection.add_adapter(mock_adapter3)
+
+        self.assertEqual(mock_adapter3.device, 'foo')
+        collection.device = None
+
+        self.assertEqual(mock_adapter1.device, None)
+
+        mock_adapter4 = MagicMock()
+        mock_adapter4.device = 'bar'
+
+        collection.add_adapter(mock_adapter4)
+
+        self.assertEqual(mock_adapter1.device, 'bar')
 
     def test_remove_adapter(self):
         collection = AdapterCollection(DummyAdapter('foo'))

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -101,7 +101,7 @@ class TestAdapterCollection(unittest.TestCase):
         collection.device = 'foo'
 
         self.assertEqual(mock_adapter1.device, 'foo')
-        self.assertEqual(mock_adapter1.device, 'foo')
+        self.assertEqual(mock_adapter2.device, 'foo')
 
         mock_adapter3 = MagicMock()
         mock_adapter3.device = 'other'

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -305,17 +305,7 @@ class TestSimulation(unittest.TestCase):
         adapter_mock = MagicMock()
         sim = Simulation(device=Mock(), adapter=adapter_mock, device_builder=MockBuilder())
 
-        set_simulation_running(sim)
-        sim._process_cycle(0.5)
-
-        self.assertNotEqual(sim.cycles, 0)
-        self.assertNotEqual(sim.runtime, 0)
-
         sim.switch_setup('foo')
 
-        self.assertEqual(sim.cycles, 0)
-        self.assertEqual(sim.runtime, 0)
-
         self.assertEqual(adapter_mock.device, 'foo')
-
         self.assertRaises(RuntimeError, sim.switch_setup, 'bar')

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -292,7 +292,7 @@ class TestSimulation(unittest.TestCase):
 
         sim = Simulation(device=Mock(), adapter=Mock(), device_builder=MockBuilder())
 
-        self.assertEqual(sim.setups, ['foo', 'bar'])
+        self.assertEqual(set(sim.setups), {'foo', 'bar'})
 
     def test_switch_setup(self):
         class MockBuilder(object):


### PR DESCRIPTION
This fixes #98.

With these changes it is possible to switch the setup at runtime via the control server. The functionality is implemented in `Simulation`.

I expect the implementation to change somewhat when all the adapter-related issues are taken up in the next release, so this implementation is very focused on providing only this new capability and nothing else.