### PR TITLE
Filter Members Exposed via Control Interface

### DIFF
--- a/lewis/core/control_server.py
+++ b/lewis/core/control_server.py
@@ -82,7 +82,7 @@ class ExposedObject(object):
 
         exposed_members = members if members else self._public_members()
         exclude = list(exclude or [])
-        if not exclude_inherited:
+        if exclude_inherited:
             for base in inspect.getmro(type(obj))[1:]:
                 exclude += dir(base)
 

--- a/lewis/core/control_server.py
+++ b/lewis/core/control_server.py
@@ -69,10 +69,10 @@ class ExposedObject(object):
     :param obj: The object to expose.
     :param members: This list of methods will be exposed. (defaults to all public members)
     :param exclude: Members in this list will not be exposed.
-    :param exclude_inherited: Should inherited members be excluded? (defaults to True)
+    :param exclude_inherited: Should inherited members be excluded? (defaults to False)
     """
 
-    def __init__(self, obj, members=None, exclude=None, exclude_inherited=True):
+    def __init__(self, obj, members=None, exclude=None, exclude_inherited=False):
         super(ExposedObject, self).__init__()
 
         self._object = obj

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -103,11 +103,13 @@ class Simulation(object):
         if control_server is None:
             return None
 
-        return ControlServer(
-            {'device': self._device,
-             'simulation': ExposedObject(self, exclude=('start', 'control_server')),
-             'interface': ExposedObject(self._adapters,
-                                        exclude=('add_adapter', 'remove_adapter', 'handle'))},
+        return ControlServer({
+            'device': self._device,
+            'simulation': ExposedObject(self, exclude=('start', 'control_server', 'log')),
+            'interface': ExposedObject(
+                self._adapters,
+                exclude=('add_adapter', 'remove_adapter', 'handle', 'log')
+            )},
             control_server)
 
     def start(self):

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -104,11 +104,19 @@ class Simulation(object):
             return None
 
         return ControlServer({
-            'device': self._device,
-            'simulation': ExposedObject(self, exclude=('start', 'control_server', 'log')),
+            'device': ExposedObject(
+                self._device,
+                exclude_inherited=True
+            ),
+            'simulation': ExposedObject(
+                self,
+                exclude=('start', 'control_server', 'log'),
+                exclude_inherited=True
+            ),
             'interface': ExposedObject(
                 self._adapters,
-                exclude=('add_adapter', 'remove_adapter', 'handle', 'log')
+                exclude=('add_adapter', 'remove_adapter', 'handle', 'log'),
+                exclude_inherited=True
             )},
             control_server)
 

--- a/lewis/devices/__init__.py
+++ b/lewis/devices/__init__.py
@@ -51,7 +51,7 @@ class StateMachineDevice(DeviceBase, CanProcessComposite):
     internally.
 
     Implementing such a device is straightforward, there are three methods
-    that *must* be overriden:
+    that *must* be overridden:
 
         - :meth:`_get_state_handlers`
         - :meth:`_get_initial_state`

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -48,7 +48,7 @@ def show_api(remote, object_name):
             raw_value = str(getattr(obj, prop))
             value_lines = raw_value.split('\n')
 
-            current_value = value_lines[0][40:] + (
+            current_value = value_lines[0][:40] + (
                 ' [...]' if len(value_lines) > 1 or len(value_lines[0]) > 40 else '')
         except ProtocolException:
             raise

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -79,7 +79,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_inherited_not_exposed(self):
-        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'))
+        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'), exclude_inherited=True)
 
         expected_methods = [':api', 'c:get', 'c:set']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -88,7 +88,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_inherited_exposed(self):
-        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'), exclude_inherited=False)
+        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'))
 
         expected_methods = [':api', 'a:get', 'a:set', 'c:get', 'c:set']
         self.assertEqual(len(rpc_object), len(expected_methods))

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -29,12 +29,16 @@ from . import assertRaisesNothing
 
 
 class TestObject(object):
-    def __init__(self):
-        self.a = 10
-        self.b = 20
+    a = 10
+    b = 20
 
+    def __init__(self):
         self.getTest = Mock()
         self.setTest = Mock()
+
+
+class TestObjectChild(TestObject):
+    c = 30
 
 
 class TestRPCObject(unittest.TestCase):
@@ -69,6 +73,24 @@ class TestRPCObject(unittest.TestCase):
         rpc_object = ExposedObject(TestObject(), members=('a', 'getTest'), exclude=('a'))
 
         expected_methods = [':api', 'getTest']
+        self.assertEqual(len(rpc_object), len(expected_methods))
+
+        for method in expected_methods:
+            self.assertTrue(method in rpc_object)
+
+    def test_inherited_not_exposed(self):
+        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'))
+
+        expected_methods = [':api', 'c:get', 'c:set']
+        self.assertEqual(len(rpc_object), len(expected_methods))
+
+        for method in expected_methods:
+            self.assertTrue(method in rpc_object)
+
+    def test_inherited_exposed(self):
+        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'), exclude_inherited=False)
+
+        expected_methods = [':api', 'a:get', 'a:set', 'c:get', 'c:set']
         self.assertEqual(len(rpc_object), len(expected_methods))
 
         for method in expected_methods:

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -166,15 +166,12 @@ class TestSimulation(unittest.TestCase):
     @patch('lewis.core.simulation.ExposedObject')
     @patch('lewis.core.simulation.ControlServer')
     def test_construct_control_server(self, mock_control_server_type, exposed_object_mock):
-        device = Mock()
-        adapter = Mock()
-
         exposed_object_mock.return_value = 'test'
-        assertRaisesNothing(self, Simulation, device=device, adapter=adapter,
+        assertRaisesNothing(self, Simulation, device=Mock(), adapter=Mock(),
                             control_server='localhost:10000')
 
         mock_control_server_type.assert_called_once_with(
-            {'device': device, 'simulation': 'test', 'interface': 'test'},
+            {'device': 'test', 'simulation': 'test', 'interface': 'test'},
             'localhost:10000')
 
     def test_start_starts_control_server(self):
@@ -233,13 +230,12 @@ class TestSimulation(unittest.TestCase):
         # The return value (= instance of ControlServer) must be specified
         control_server_mock.return_value = Mock()
         exposed_object_mock.return_value = 'test'
-        device_mock = Mock()
 
-        env = Simulation(device=device_mock, adapter=Mock())
+        env = Simulation(device=Mock(), adapter=Mock())
 
         assertRaisesNothing(self, setattr, env, 'control_server', '127.0.0.1:10001')
         control_server_mock.assert_called_once_with(
-            {'device': device_mock, 'simulation': 'test', 'interface': 'test'}, '127.0.0.1:10001')
+            {'device': 'test', 'simulation': 'test', 'interface': 'test'}, '127.0.0.1:10001')
 
         control_server_mock.reset_mock()
 
@@ -253,7 +249,7 @@ class TestSimulation(unittest.TestCase):
 
         # The server is started automatically when the simulation is running
         control_server_mock.assert_called_once_with(
-            {'device': device_mock, 'simulation': 'test', 'interface': 'test'}, '127.0.0.1:10002')
+            {'device': 'test', 'simulation': 'test', 'interface': 'test'}, '127.0.0.1:10002')
 
         # The instance must have one call to start_server
         control_server_mock.return_value.assert_has_calls([call.start_server()])


### PR DESCRIPTION
Fixes #194.

Filters members exposed by default (not overridden via the `members` param) via `ExposedObject`.

Members filtered, in addition to the previous "starting with `_`" condition, are anything defined or inherited in `Device` or `StateMachineDevice` and specifically "`log`". 

`log` had to be done explicitly since it is added dynamically by a decorator.

Also fixed an error in `control.py`... not sure how that slipped past both of us! :laughing: 