### PR TITLE
Adapters do not parse command line arguments any more

### DIFF
--- a/docs/developer_guide/writing_devices.rst
+++ b/docs/developer_guide/writing_devices.rst
@@ -296,7 +296,7 @@ started using the ``-k`` parameter of ``lewis.py``:
 
 ::
 
-    $ ./lewis.py -k lewis.examples example_motor -- -b 127.0.0.1 -p 9999
+    $ ./lewis.py -k lewis.examples example_motor -p "stream: {bind_address: 127.0.0.1, port: 9999}"
 
 All functionality described in the
 :ref:`user_guide`, such as accessing the device and the simulation via the

--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -5,10 +5,39 @@ Release 1.0.3
 
 This release is currently in progress.
 
+Command line interface change
+-----------------------------
+
+The way options are passed to the adapters has changed completely, the functionality has been
+merged into the ``-p``-argument, which has a new long version now, ``--adapter-options``.
+
+For the default adapter options, it is still possible to use the ``lewis``-command with ``-p``
+in the same way as before:
+
+.. ::
+
+   $ lewis -p stream linkam_t95
+
+To supply options, such as the address and port to bind to, the argument accepts an extended
+dictionary syntax now:
+
+.. ::
+
+   $ lewis linkam_t95 -p "stream: {bind_address: localhost, port: 9998}"
+
+The space after each colon is significant, it can not be left out. For strings containing
+special characters, such as colons, it is necessary to quote them:
+
+.. ::
+
+   $ lewis chopper -p "epics: {prefix: 'PREF:'}"
+
 New features
 ------------
 
- - The device setup can be changed at runtime through the control server. It is not possible to switch to another device, only setups of the same device can be used. To query available setups:
+ - The device setup can be changed at runtime through the control server. It is not possible to
+   switch to another device, only setups of the same device can be used.
+   To query available setups:
 
    .. ::
 

--- a/docs/user_guide/adapter_specifics.rst
+++ b/docs/user_guide/adapter_specifics.rst
@@ -6,16 +6,15 @@ EPICS Adapter Specifics
 
 The EPICS adapter takes only one optional argument:
 
--  ``-p`` / ``--prefix``: This string is prefixed to all PV names.
-   Defaults to empty / no prefix.
+-  ``prefix``: This string is prefixed to all PV names. Defaults to empty / no prefix.
 
-Arguments meant for the adapter should be separated from general
-Lewis arguments by a free-standing ``--``. For example:
+Arguments meant for the adapter can be specified with the adapter options.
+For example:
 
 ::
 
-    $ docker run -itd dmscid/lewis -p epics chopper -- -p SIM1:
-    $ python lewis.py -p epics chopper -- --prefix SIM2:
+    $ docker run -itd dmscid/lewis chopper -p "epics: {prefix: 'SIM1:'}"
+    $ python lewis.py chopper --adapter-options "epics: {prefix: 'SIM2:'}"
 
 When using the EPICS adapter within a docker container, the PV will be
 served on the docker0 network (172.17.0.0/16).
@@ -41,18 +40,19 @@ Stream Adapter Specifics
 
 The TCP Stream adapter has the following optional arguments:
 
--  ``-b`` / ``--bind-address``: Address of network adapter to listen on.
+-  ``bind_address``: Address of network adapter to listen on.
    Defaults to "0.0.0.0" (all network adapters).
--  ``-p`` / ``--port``: Port to listen for connections on. Defaults to
-   9999.
+-  ``port``: Port to listen for connections on. Defaults to 9999.
+-  ``telnet_mode``: When True, overrides both in and out terminators
+   to CRNL for telnet compatibility. Defaults to False.
 
-Arguments meant for the adapter should be separated from general
-Lewis arguments by a free-standing ``--``. For example:
+Arguments meant for the adapter can be specified with the adapter options.
+For example:
 
 ::
 
-    $ docker run -itd dmscid/lewis -p stream linkam_t95 -- -p 1234
-    $ python lewis.py -p stream linkam_t95 -- --bind-address localhost
+    $ docker run -itd dmscid/lewis linkam_t95 --adapter-options "stream: {port: 1234}"
+    $ python lewis.py linkam_t95 -p "stream: {bind_address: localhost, port: 1234}"
 
 When using Lewis via Docker on Windows and OSX, the container will be
 running inside a virtual machine, and so the port it is listening on
@@ -61,10 +61,10 @@ VM, an additional argument must be passed to Docker to forward the port:
 
 ::
 
-    $ docker run -it -p 1234:4321 dmscid/lewis -p stream linkam_t95 -- -p 4321
+    $ docker run -it -p 1234:4321 dmscid/lewis linkam_t95 -p "stream: {port: 4321}"
     $ telnet 192.168.99.100 1234
 
-This ``-p`` argument links port 4321 on the container to port 1234 on
+This port option links port 4321 on the container to port 1234 on
 the VM network adapter. It must appear after ``docker run`` and before
 ``dmscid/lewis``. This allows us to connect to the container from
 outside of the VM, in this case using Telnet. The ``192.168.99.100`` IP

--- a/docs/user_guide/remote_access_devices.rst
+++ b/docs/user_guide/remote_access_devices.rst
@@ -10,7 +10,7 @@ the ``-r`` option with a ``host:port`` string to the simulation:
 
 ::
 
-    $ lewis -r 127.0.0.1:10000 chopper -- -p SIM:
+    $ lewis chopper -r 127.0.0.1:10000 -p "epics: {prefix: 'SIM:'}"
 
 Now the device can be controlled via the ``lewis-control.py``-script
 in a different terminal window. The service can be queried to show the

--- a/docs/user_guide/usage_with_docker.rst
+++ b/docs/user_guide/usage_with_docker.rst
@@ -23,23 +23,23 @@ general format:
 
 ::
 
-    $ docker run -it [docker args] dmscid/lewis [lewis args] [-- [adapter args]]
+    $ docker run -it [docker args] dmscid/lewis [device] [arguments]
 
-For example, to simulate a Linkam T95 **d**\ evice and expose it via the
+For example, to simulate a Linkam T95 device and expose it via the
 TCP Stream **p**\ rotocol:
 
 ::
 
-    $ docker run -it dmscid/lewis -p stream linkam_t95
+    $ docker run -it dmscid/lewis linkam_t95 -p stream
 
 To change the rate at which simulation cycles are calculated, increase
 or decrease the cycle delay, via the ``-c`` or ``--cycle-delay`` option.
-Smaller values mean more cycles per second, 0 means greates possible
+Smaller values mean more cycles per second, 0 means fastest possible
 speed.
 
 ::
 
-    $ docker run -it dmscid/lewis -p stream -c 0.05 linkam_t95
+    $ docker run -it dmscid/lewis linkam_t95 -p stream -c 0.05
 
 For long running devices it might be useful to speed up the simulation
 using the ``-e`` or ``--speed`` parameter, which is a factor by which
@@ -48,7 +48,7 @@ simulation cycle. To run a simulation 10 times faster:
 
 ::
 
-    $ docker run -it dmscid/lewis -p stream -e 10 linkam_t95
+    $ docker run -it dmscid/lewis linkam_t95 -p stream -e 10
 
 Details about parameters for the various adapters, and differences
 between OSes are covered in the "Adapter Specifics" sections.

--- a/docs/user_guide/usage_with_python.rst
+++ b/docs/user_guide/usage_with_python.rst
@@ -139,14 +139,14 @@ directory):
 
 ::
 
-    $ python lewis.py [lewis args] [-- [adapter args]]
+    $ python lewis.py device_name [arguments]
 
 You can then run Lewis as follows (from within the lewis
 directory):
 
 ::
 
-    $ python lewis.py -p epics chopper
+    $ python lewis.py chopper -p epics
 
 Details about parameters for the various adapters, and differences
 between OSes are covered in the "Adapter Specifics" sections.

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from argparse import ArgumentParser
 from datetime import datetime
 import inspect
 
@@ -279,15 +278,23 @@ class EpicsAdapter(Adapter):
     via EPICS might involve writing a value to a PV, whereas other protocols may
     offer an RPC-way of achieving the same thing.
 
-    :param arguments: Command line arguments to parse.
+    It's possible to configure the prefix for the PVs provided by this adapter. The
+    corresponding key in the ``options`` dictionary is called ``prefix``:
+
+    .. sourcecode:: Python
+
+        options = {
+            'prefix': 'PVPREFIX:'
+        }
+
+    :param options: Dictionary with options.
     """
     protocol = 'epics'
     pvs = None
+    default_options = {'prefix': ''}
 
-    def __init__(self, arguments=None):
-        super(EpicsAdapter, self).__init__(arguments)
-
-        self._options = self._parse_arguments(arguments or [])
+    def __init__(self, options=None):
+        super(EpicsAdapter, self).__init__(options)
 
         self._server = None
         self._driver = None
@@ -377,11 +384,6 @@ class EpicsAdapter(Adapter):
     @property
     def is_running(self):
         return self._server is not None
-
-    def _parse_arguments(self, arguments):
-        parser = ArgumentParser(description="Adapter to expose a device via EPICS")
-        parser.add_argument('-p', '--prefix', help='Prefix to use for all PVs', default='')
-        return parser.parse_args(arguments)
 
     def handle(self, cycle_delay=0.1):
         """

--- a/lewis/adapters/modbus.py
+++ b/lewis/adapters/modbus.py
@@ -40,7 +40,6 @@ import struct
 
 from copy import deepcopy
 from math import ceil
-from argparse import ArgumentParser
 
 from lewis.core.adapters import Adapter
 from lewis.core.logging import has_log
@@ -585,19 +584,15 @@ class ModbusAdapter(Adapter):
     ir = None
     hr = None
 
-    def __init__(self, arguments=None):
-        super(ModbusAdapter, self).__init__(arguments)
+    default_options = {
+        'bind_address': '0.0.0.0',
+        'port': 502
+    }
 
-        self._options = self._parse_arguments(arguments or [])
+    def __init__(self, options=None):
+        super(ModbusAdapter, self).__init__(options)
+
         self._server = None
-
-    def _parse_arguments(self, arguments):
-        parser = ArgumentParser(description='Adapter to expose a device via Modbus TCP')
-        parser.add_argument('-b', '--bind-address', default='0.0.0.0',
-                            help='IP Address to bind and listen for connections on')
-        parser.add_argument('-p', '--port', type=int, default=502,
-                            help='Port to listen for connections on')
-        return parser.parse_args(arguments)
 
     def start_server(self):
         self._server = ModbusServer(self._options.bind_address, self._options.port, self)

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -22,7 +22,6 @@ import asyncore
 import inspect
 import re
 import socket
-from argparse import ArgumentParser
 
 from six import b
 
@@ -460,7 +459,13 @@ class StreamAdapter(Adapter):
     In addition, the :meth:`handle_error`-method can be overridden. It is called when an exception
     is raised while handling commands.
 
-    :param arguments: Command line arguments.
+    Available adapter options are:
+
+     - bind_address: IP of network adapter to bind on (defaults to 0.0.0.0, or all adapters)
+     - port: Port to listen on (defaults to 9999)
+     - telnet_mode: When True, overrides in- and out-terminator for CRNL (defaults to False)
+
+    :param options: Dictionary with options.
     """
     protocol = 'stream'
 
@@ -469,10 +474,14 @@ class StreamAdapter(Adapter):
 
     commands = None
 
-    def __init__(self, arguments=None):
-        super(StreamAdapter, self).__init__(arguments)
+    default_options = {
+        'telnet_mode': False,
+        'bind_address': '0.0.0.0',
+        'port': 9999
+    }
 
-        self._options = self._parse_arguments(arguments or [])
+    def __init__(self, options=None):
+        super(StreamAdapter, self).__init__(options)
 
         if self._options.telnet_mode:
             self.in_terminator = '\r\n'
@@ -552,16 +561,6 @@ class StreamAdapter(Adapter):
     @property
     def is_running(self):
         return self._server is not None
-
-    def _parse_arguments(self, arguments):
-        parser = ArgumentParser(description='Adapter to expose a device via TCP Stream')
-        parser.add_argument('-b', '--bind-address', default='0.0.0.0',
-                            help='IP Address to bind and listen for connections on')
-        parser.add_argument('-p', '--port', type=int, default=9999,
-                            help='Port to listen for connections on')
-        parser.add_argument('-t', '--telnet-mode', action='store_true',
-                            help='Override terminators to be telnet compatible')
-        return parser.parse_args(arguments)
 
     def handle_error(self, request, error):
         """

--- a/lewis/core/devices.py
+++ b/lewis/core/devices.py
@@ -274,6 +274,9 @@ class DeviceBuilder(object):
                 'device module \'{}\' provides multiple device types so that no meaningful '
                 'default can be deduced.'.format(setup_name, self.name))
 
+    def get_interface_type(self, protocol=None):
+        return self.interfaces[protocol]
+
     def create_interface(self, protocol=None, *args, **kwargs):
         """
         Returns an interface that implements the provided protocol. If the protocol is not

--- a/lewis/core/utils.py
+++ b/lewis/core/utils.py
@@ -139,7 +139,8 @@ def dict_strict_update(base_dict, update_dict):
     if len(additional_keys) > 0:
         raise RuntimeError(
             'The update dictionary contains keys that are not part of '
-            'the base dictionary: {}'.format(str(additional_keys)))
+            'the base dictionary: {}'.format(str(additional_keys)),
+            additional_keys)
 
     base_dict.update(update_dict)
 

--- a/lewis/devices/chopper/chopper_documentation.rst
+++ b/lewis/devices/chopper/chopper_documentation.rst
@@ -26,7 +26,7 @@ Start using Docker:
 
 ::
 
-    $ docker run -it dmscid/lewis --protocol epics chopper -- --prefix SIM:
+    $ docker run -it dmscid/lewis chopper -p "epics: {prefix: 'SIM:'}"
 
 If running on Windows or OSX, you will additionally need to start a
 `Gateway <https://hub.docker.com/r/dmscid/epics-gateway/>`__ if you want
@@ -36,7 +36,7 @@ Start using Python:
 
 ::
 
-    $ python simulation.py --protocol epics chopper -- --prefix SIM:
+    $ python simulation.py chopper -p "epic: {prefix: 'SIM:'}"
 
 The ``--`` separates arguments of the protocol adapter from the
 simulation's arguments.

--- a/lewis/examples/simple_device/__init__.py
+++ b/lewis/examples/simple_device/__init__.py
@@ -22,13 +22,8 @@ from lewis.devices import Device
 from lewis.adapters.stream import StreamAdapter, Var, Cmd
 
 
-class bla(dict):
-    pass
-
-
 class VerySimpleDevice(Device):
     param = 10
-    g = bla()
 
 
 class VerySimpleInterface(StreamAdapter):

--- a/lewis/examples/simple_device/__init__.py
+++ b/lewis/examples/simple_device/__init__.py
@@ -22,8 +22,13 @@ from lewis.devices import Device
 from lewis.adapters.stream import StreamAdapter, Var, Cmd
 
 
+class bla(dict):
+    pass
+
+
 class VerySimpleDevice(Device):
     param = 10
+    g = bla()
 
 
 class VerySimpleInterface(StreamAdapter):

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -142,18 +142,18 @@ def do_run_simulation(argument_list=None):  # noqa: C901
     protocol = None
     options = {}
 
-    try:
-        adapter_options = yaml.load(arguments.adapter_options)
-    except yaml.YAMLError:
-        raise LewisException(
-            'It was not possible to parse this adapter option specification:\n'
-            '    %s\n'
-            'Correct formats for the -p argument are:\n'
-            '    -p protocol\n'
-            '    -p "protocol: {option: \'val\', option2: 34}"\n'
-            'The spaces after the colons are significant!' % (arguments.adapter_options))
+    if arguments.adapter_options:
+        try:
+            adapter_options = yaml.load(arguments.adapter_options)
+        except yaml.YAMLError:
+            raise LewisException(
+                'It was not possible to parse this adapter option specification:\n'
+                '    %s\n'
+                'Correct formats for the -p argument are:\n'
+                '    -p protocol\n'
+                '    -p "protocol: {option: \'val\', option2: 34}"\n'
+                'The spaces after the colons are significant!' % arguments.adapter_options)
 
-    if adapter_options:
         if isinstance(adapter_options, string_types):
             protocol = adapter_options
             options = {}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ json-rpc
 sphinx>=1.4.5
 sphinx_rtd_theme
 semantic_version
+PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ six
 pyzmq
 json-rpc
 semantic_version
+PyYAML
 
 # If you want to use EPICS based devices, uncomment the pcaspy-line.
 # It requires a working EPICS installation, please refer to the

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -5,6 +5,7 @@ import inspect
 
 from lewis.adapters.stream import StreamAdapter
 from lewis.core.adapters import is_adapter, Adapter, AdapterCollection
+from lewis.core.exceptions import LewisException
 from . import assertRaisesNothing
 
 
@@ -30,8 +31,13 @@ class DummyAdapter(Adapter):
     A dummy adapter for tests.
     """
 
-    def __init__(self, protocol, running=False):
-        super(DummyAdapter, self).__init__(None)
+    default_options = {
+        'foo': True,
+        'bar': False,
+    }
+
+    def __init__(self, protocol, running=False, options=None):
+        super(DummyAdapter, self).__init__(options)
         self.protocol = protocol
         self._running = running
 
@@ -170,3 +176,7 @@ class TestAdapterCollection(unittest.TestCase):
         collection.handle(0.1)
         sleep_mock.assert_has_calls([call(0.05)])
         adapter_mock.assert_has_calls([call(0.05)])
+
+    def test_options(self):
+        assertRaisesNothing(self, DummyAdapter, 'protocol', options={'bar': 2, 'foo': 3})
+        self.assertRaises(LewisException, DummyAdapter, 'protocol', options={'invalid': False})


### PR DESCRIPTION
The fixes #209.

The command line argument parsing for adapters has been generalized and taken out of the adapters, which now accept an options dictionary instead. The command line option `-p` has changed syntax.