### PR TITLE
Implement "verification mode"

### DIFF
--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -61,6 +61,9 @@ New features
    This way using devices from different sources becomes more reliable for users with different
    versions of Lewis, or hint them to update.
 
+ - A new flag ``-V/--verify`` has been added to the ``lewis``-script. When activated, it sets
+   the output level to ``debug`` and exits before actually starting the simulation. This can
+   help diagnose problems with device modules or input parameters.
 
 Bug fixes and other improvements
 --------------------------------

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -102,6 +102,12 @@ class Simulation(object):
         self._control_server = None  # Just initialize to None and use property setter afterwards
         self.control_server = control_server
 
+        self.log.debug(
+            'Created simulation. Device type: %s, Protocol: %s, Possible setups for '
+            'switching: %s, Control server: %s', device.__class__.__name__, adapter.protocol,
+            ', '.join(device_builder.setups.keys()) if device_builder else None,
+            control_server)
+
     def _create_control_server(self, control_server):
         if control_server is None:
             return None

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -93,6 +93,10 @@ other_args.add_argument(
     choices=['none', 'critical', 'error', 'warning', 'info', 'debug'],
     help='Level of detail for logging to stderr.')
 other_args.add_argument(
+    '-V', '--verify', action='store_true',
+    help='Sets the output level to \'debug\' and aborts before starting the device simulation. '
+         'This is intended to help with diagnosing problems with devices or input arguments.')
+other_args.add_argument(
     '-v', '--version', action='store_true',
     help='Prints the version and exits.')
 other_args.add_argument(
@@ -148,9 +152,10 @@ def run_simulation(argument_list=None):  # noqa: C901
             print(__version__)
             return
 
-        if arguments.output_level != 'none':
-            logging.basicConfig(level=getattr(logging, arguments.output_level.upper()),
-                                format=default_log_format)
+        loglevel = 'debug' if arguments.verify else arguments.output_level
+        if loglevel != 'none':
+            logging.basicConfig(
+                level=getattr(logging, loglevel.upper()), format=default_log_format)
 
         if arguments.add_path is not None:
             sys.path.append(os.path.abspath(arguments.add_path))
@@ -183,11 +188,12 @@ def run_simulation(argument_list=None):  # noqa: C901
         simulation.cycle_delay = arguments.cycle_delay
         simulation.speed = arguments.speed
 
-        try:
-            simulation.start()
-        except KeyboardInterrupt:
-            print('\nInterrupt received; shutting down. Goodbye, cruel world!')
-            simulation.log.critical('Simulation aborted by user interaction')
+        if not arguments.verify:
+            try:
+                simulation.start()
+            except KeyboardInterrupt:
+                print('\nInterrupt received; shutting down. Goodbye, cruel world!')
+                simulation.log.critical('Simulation aborted by user interaction')
 
     except LewisException as e:
         print('\n'.join(('An error occurred:', e.message)))

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -158,7 +158,9 @@ def run_simulation(argument_list=None):  # noqa: C901
                 level=getattr(logging, loglevel.upper()), format=default_log_format)
 
         if arguments.add_path is not None:
-            sys.path.append(os.path.abspath(arguments.add_path))
+            additional_path = os.path.abspath(arguments.add_path)
+            logging.getLogger().debug('Extending path with: %s', additional_path)
+            sys.path.append(additional_path)
 
         simulation_factory = SimulationFactory(arguments.device_package,
                                                arguments.relaxed_versions)
@@ -196,4 +198,4 @@ def run_simulation(argument_list=None):  # noqa: C901
                 simulation.log.critical('Simulation aborted by user interaction')
 
     except LewisException as e:
-        print('\n'.join(('An error occurred:', e.message)))
+        print('\n'.join(('An error occurred:', str(e))))


### PR DESCRIPTION
This fixes #199.

After discussing earlier this week, the easiest solution seemed to be an additional parameter for the `lewis` script (`-V/--verify`) which simply activates debug level logging and aborts before actually starting the simulation. I've added a bit more debug output to the device discovery process to give more information at that stage.

This PR does not implement all possible debug output - this is something we can pick up on in the next release.