### PR TITLE
Add new flag to print adapter options

### DIFF
--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -32,6 +32,12 @@ special characters, such as colons, it is necessary to quote them:
 
    $ lewis chopper -p "epics: {prefix: 'PREF:'}"
 
+To see what options can be specified, use the new ``-L/--list-adapter-options`` flag:
+
+::
+
+   $ lewis chopper -p epics -L
+
 New features
 ------------
 

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -333,6 +333,17 @@ class AdapterCollection(object):
 
         return status_dict
 
+    def configuration(self, *args):
+        """
+        Returns a dictionary that contains the options for the specified adapter. The dictionary
+        keys are the adapter protocols.
+
+        :param args: List of protocols for which to list options, empty for all adapters.
+        :return: Dict of protocol: option-dict pairs.
+        """
+        return {adapter.protocol: adapter._options._asdict()
+                for adapter in self._get_adapters(args)}
+
     def documentation(self, *args):
         """
         Returns the concatenated documentation for the adapters specified by the supplied

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -60,6 +60,10 @@ device_args.add_argument(
     '-l', '--list-protocols', action='store_true',
     help='List available protocols for selected device.')
 device_args.add_argument(
+    '-L', '--list-adapter-options', action='store_true',
+    help='List available configuration options and their value. Values that have not been '
+         'modified in the -p argument are default values.')
+device_args.add_argument(
     '-i', '--show-interface', action='store_true',
     help='Show command interface of device interface.')
 device_args.add_argument(
@@ -185,6 +189,17 @@ def run_simulation(argument_list=None):  # noqa: C901
 
         if arguments.show_interface:
             print(simulation._adapters.documentation())
+            return
+
+        if arguments.list_adapter_options:
+            configurations = simulation._adapters.configuration()
+
+            for protocol, options in configurations.items():
+                print('{}:'.format(protocol))
+
+                for opt, val in options.items():
+                    print('    {} = {}'.format(opt, val))
+
             return
 
         simulation.cycle_delay = arguments.cycle_delay

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -81,6 +81,10 @@ class TestAdapter(unittest.TestCase):
             bind_mock.assert_called_once()
             self.assertEqual(adapter.device, None)
 
+    def test_options(self):
+        assertRaisesNothing(self, DummyAdapter, 'protocol', options={'bar': 2, 'foo': 3})
+        self.assertRaises(LewisException, DummyAdapter, 'protocol', options={'invalid': False})
+
 
 class TestAdapterCollection(unittest.TestCase):
     def test_add_adapter(self):
@@ -177,6 +181,24 @@ class TestAdapterCollection(unittest.TestCase):
         sleep_mock.assert_has_calls([call(0.05)])
         adapter_mock.assert_has_calls([call(0.05)])
 
-    def test_options(self):
-        assertRaisesNothing(self, DummyAdapter, 'protocol', options={'bar': 2, 'foo': 3})
-        self.assertRaises(LewisException, DummyAdapter, 'protocol', options={'invalid': False})
+    def test_configuration(self):
+        collection = AdapterCollection(
+            DummyAdapter('protocol_a', options={'bar': 2, 'foo': 3}),
+            DummyAdapter('protocol_b', options={'bar': True, 'foo': False}))
+
+        self.assertDictEqual(collection.configuration(),
+                             {
+                                 'protocol_a': {'bar': 2, 'foo': 3},
+                                 'protocol_b': {'bar': True,
+                                                'foo': False}
+                             })
+
+        self.assertDictEqual(collection.configuration('protocol_a'),
+                             {
+                                 'protocol_a': {'bar': 2, 'foo': 3},
+                             })
+
+        self.assertDictEqual(collection.configuration('protocol_b'),
+                             {
+                                 'protocol_b': {'bar': True, 'foo': False},
+                             })


### PR DESCRIPTION
This fixes #220.

Specifying the `-L` option should print the adapter's configuration. It prints the actual configuration, not the default value (although that could be added as well).

It's also automatically available via the control server as `lewis-control interface configuration`.