### PR TITLE
Preparations for release 1.0.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = u'2016-2017, European Spallation Source ERIC'
 author = u'Michael Hart, Michael Wedel, Owen Arnold'
 
 version = u'1.0'
-release = u'1.0.2'
+release = u'1.0.3'
 
 language = None
 

--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -7,6 +7,7 @@ called "Plankton").
 .. toctree::
     :maxdepth: 1
 
+    release_1_0_3
     release_1_0_2
     release_1_0_1
     release_1_0_0

--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -1,9 +1,11 @@
-:orphan:
-
 Release 1.0.3
 =============
 
-This release is currently in progress.
+This version was released on March 24th, 2017. In this release, the :mod:`~lewis.adapters.epics`-
+module has received some updates. Some important groundwork for future improvements has been
+laid as well, which resulted in the ability to switch device setups at runtime via the control
+server and a new command line syntax for configuring communications. The control server and client
+have been improved as well.
 
 Command line interface change
 -----------------------------

--- a/lewis/__init__.py
+++ b/lewis/__init__.py
@@ -17,4 +17,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # *********************************************************************
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='lewis',
-    version='1.0.2',
+    version='1.0.3',
     description='LeWIS - Let\'s Write Intricate Simulators!',
     long_description=readme(),
     url='https://github.com/DMSC-Instrument-Data/lewis',
@@ -55,7 +55,7 @@ setup(
     keywords='hardware simulation controls',
     packages=find_packages(exclude=['docs', 'test']),
 
-    install_requires=['six', 'pyzmq', 'json-rpc'],
+    install_requires=['six', 'pyzmq', 'json-rpc', 'semantic_version', 'PyYAML'],
 
     extras_require={
         'epics': ['pcaspy'],


### PR DESCRIPTION
These are the final preparations for release 1.0.3. Version numbers are bumped, release notes included in the actual documentation. Once it's merged, we can add a tag to master and upload packages/docker images.