### PR TITLE
Handle case of __name__less callables

### DIFF
--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -172,7 +172,9 @@ class Func(object):
             raise RuntimeError(
                 'The number of arguments for function \'{}\' matched by pattern '
                 '\'{}\' is not compatible with number of defined '
-                'groups in pattern ({}).'.format(func.__name__, pattern, self.pattern.groups))
+                'groups in pattern ({}).'.format(
+                    getattr(func, '__name__', repr(func)), pattern, self.pattern.groups
+                ))
 
         if argument_mappings is not None and (self.pattern.groups != len(argument_mappings)):
             raise RuntimeError(


### PR DESCRIPTION
Minor edge case. Some callables do not have a `__name__` attribute.

For example:
```python
class Foo(object):
    def __call__(self, x):
        print(x)

>>> foo = Foo()
>>> foo('bar')
bar
>>> foo.__name__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Foo' object has no attribute '__name__'
```
This applies to partials as well.

This PR will display `repr(func)` when `func.__name__` is not available.