### PR TITLE
Place adapter in separate thread

### DIFF
--- a/docs/release_notes/release_1_1_0.rst
+++ b/docs/release_notes/release_1_1_0.rst
@@ -8,11 +8,11 @@ This release is currently in progress.
 New features
 ------------
 
-The control client, lewis-control, now provides a version argument via ``--version`` or ``-v``. 
+The control client, lewis-control, now provides a version argument via ``--version`` or ``-v``.
 
 ::
 
-   $ lewis-control -v 
+   $ lewis-control -v
 
 Bug fixes and other improvements
 --------------------------------
@@ -29,6 +29,10 @@ Bug fixes and other improvements
    The logo was made using `inkscape`_, the font in the logo is `Rubik`_. The two PNGs and
    also the SVGs are in the `source repository`_, feel free to include them in presentations,
    posters.
+
+ - Adapters now run in a different thread than the simulation itself. The consequence of this is
+   that slow network communication or expensive computations in the device do not influence
+   one another anymore. Otherwise, communication still works exactly like in previous versions.
 
 Upgrade guide
 -------------

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -513,7 +513,8 @@ class EpicsAdapter(Adapter):
             self._server = SimpleServer()
             self._server.createPV(prefix=self._options.prefix,
                                   pvdb={k: v.config for k, v in self.interface.bound_pvs.items()})
-            self._driver = PropertyExposingDriver(interface=self.interface, device_lock=self.device_lock)
+            self._driver = PropertyExposingDriver(interface=self.interface,
+                                                  device_lock=self.device_lock)
             self._driver.process_pv_updates(force=True)
 
             self.log.info('Started serving PVs: %s',

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -426,35 +426,37 @@ class PropertyExposingDriver(Driver):
         return False
 
     def process_pv_updates(self, force=False):
-        dt = seconds_since(self._last_update_call or datetime.now())
-        # Updates bound parameters as needed
+        """
+        Update PV values that have changed for PVs that are due to update according to their
+        respective poll interval timers.
 
+        :param force: If True, will force updates to all PVs regardless of timers.
+        """
+        dt = seconds_since(self._last_update_call or datetime.now())
+
+        # Cache details of PVs that need to update
         updates = []
 
-        for pv, pv_object in iteritems(self._interface.bound_pvs):
-            if pv not in self._timers:
-                self._timers[pv] = 0.0
+        with self._device_lock:
+            for pv, pv_object in iteritems(self._interface.bound_pvs):
+                self._timers[pv] = self._timers.get(pv, 0.0) + dt
+                if self._timers[pv] >= pv_object.poll_interval or force:
+                    try:
+                        updates.append((pv, pv_object.value, pv_object.meta))
+                    except (AttributeError, TypeError):
+                        self.log.exception('An error occurred while updating PV %s.', pv)
+                    finally:
+                        self._timers[pv] = 0.0
 
-            self._timers[pv] += dt
-            if self._timers[pv] >= pv_object.poll_interval or force:
-                try:
-                    with self._device_lock:
-                        new_value = pv_object.value
-
-                        self.setParam(pv, new_value)
-                        self.setParamInfo(pv, pv_object.meta)
-
-                        updates.append((pv, new_value))
-                except (AttributeError, TypeError):
-                    self.log.exception('An error occurred while updating PV %s.', pv)
-                finally:
-                    self._timers[pv] = 0.0
+        for pv, value, info in updates:
+            self.setParam(pv, value)
+            self.setParamInfo(pv, info)
 
         self.updatePVs()
 
         if updates:
             self.log.info('Processed PV updates: %s',
-                          ', '.join(('{}={}'.format(pv, val) for pv, val in updates)))
+                          ', '.join(('{}={}'.format(pv, val) for pv, val, _ in updates)))
 
         self._last_update_call = datetime.now()
 
@@ -511,7 +513,7 @@ class EpicsAdapter(Adapter):
             self._server = SimpleServer()
             self._server.createPV(prefix=self._options.prefix,
                                   pvdb={k: v.config for k, v in self.interface.bound_pvs.items()})
-            self._driver = PropertyExposingDriver(interface=self.interface, device_lock=self.lock)
+            self._driver = PropertyExposingDriver(interface=self.interface, device_lock=self.device_lock)
             self._driver.process_pv_updates(force=True)
 
             self.log.info('Started serving PVs: %s',

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -477,7 +477,7 @@ class StreamAdapter(Adapter):
                 self.interface.out_terminator = '\r\n'
 
             self._server = StreamServer(self._options.bind_address, self._options.port,
-                                        self.interface, self.lock)
+                                        self.interface, self.device_lock)
 
     def stop_server(self):
         if self._server is not None:

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -91,7 +91,7 @@ class Adapter(object):
         super(Adapter, self).__init__()
         self._interface = None
 
-        self.lock = NoLock()
+        self.device_lock = NoLock()
 
         options = options or {}
         combined_options = dict(self.default_options)

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -32,8 +32,16 @@ from lewis.core.utils import dict_strict_update
 
 
 class NoLock(object):
+    """
+    A dummy context manager that raises a RuntimeError when it's used. This makes it easier to
+    detect cases where an :class:`Adapter` has not received the proper lock-object to make sure
+    that device/interface access is synchronous.
+    """
+
     def __enter__(self):
-        pass
+        raise RuntimeError(
+            'The attempted action requires a proper threading.Lock-object, '
+            'but none was available.')
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
@@ -220,7 +228,7 @@ class AdapterCollection(object):
         This lock is passed to each adapter when it's started. It's supposed to be used to ensure
         that the device is only accessed from one thread at a time, for example during network IO.
         :class:`~lewis.core.simulation.Simulation` uses this lock to block the device during the
-        simulation cycle calculations. 
+        simulation cycle calculations.
         """
         return self._lock
 
@@ -277,7 +285,7 @@ class AdapterCollection(object):
             adapter_thread.start()
 
     def _adapter_loop(self, adapter, dt):
-        adapter.lock = self._lock
+        adapter.lock = self._lock  # This ensures that the adapter is using the correct lock.
         adapter.start_server()
 
         self.log.debug('Starting adapter loop.')

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -207,6 +207,7 @@ class AdapterCollection(object):
 
     def __init__(self, *args):
         self._adapters = {}
+        self.lock = NoLock()
 
         for adapter in args:
             self.add_adapter(adapter)
@@ -348,6 +349,8 @@ class MultiThreadedAdapterCollection(AdapterCollection):
         self._threads = {}
         self._stop = {}
 
+        self.lock = threading.Lock()
+
     def _start_server(self, adapter):
         if adapter.protocol not in self._threads:
             adapter_thread = threading.Thread(target=self._do_handle, args=(adapter, 0.1))
@@ -363,6 +366,7 @@ class MultiThreadedAdapterCollection(AdapterCollection):
             del self._threads[adapter.protocol]
 
     def _do_handle(self, adapter, dt):
+        adapter.lock = self.lock
         adapter.start_server()
 
         while not self._stop.get(adapter.protocol, False):

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -32,6 +32,14 @@ from lewis.core.logging import has_log
 from lewis.core.utils import dict_strict_update
 
 
+class NoLock(object):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
 @has_log
 class Adapter(object):
     """
@@ -70,6 +78,7 @@ class Adapter(object):
     def __init__(self, options=None):
         super(Adapter, self).__init__()
         self._interface = None
+        self.lock = NoLock()
 
         options = options or {}
 
@@ -270,7 +279,7 @@ class AdapterCollection(object):
         :param args: List of protocols for which to stop adapters or empty for all.
         """
         for adapter in self._get_adapters(args):
-            self.log.info('Disonnecting device interface for protocol \'%s\'', adapter.protocol)
+            self.log.info('Disconnecting device interface for protocol \'%s\'', adapter.protocol)
             self._stop_server(adapter)
 
     def _stop_server(self, adapter):

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -77,6 +77,11 @@ class Adapter(object):
     the dictionary are accessible as properties of the ``_options``-member. Only keys that are
     in the ``default_options`` member of the class are accepted. Inheriting classes must override
     ``default_options`` to be a dictionary with the possible options for the adapter.
+    
+    Each adapter has a ``lock`` member, which contains a :class:`NoLock` by default. To make
+    device access thread-safe, any adapter should acquire this lock before interacting with
+    the device (or interface). This means that before starting the server component of an Adapter,
+    a proper Lock-object needs to be assigned to ``lock``.
 
     :param options: Configuration options for the adapter.
     """
@@ -206,8 +211,7 @@ class AdapterCollection(object):
     names at all will start/stop all adapters. These semantics also apply for :meth:`is_connected`
     and `documentation`.
 
-    The :meth:`handle` implementation will call all the stored adapters' ``handle`` methods if they
-    are running, otherwise ``time.sleep`` is called.
+    This class also makes sure that all adapters use the same Lock for device interaction.
 
     :param args: List of adapters to add to the container
     """

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -77,7 +77,7 @@ class Adapter(object):
     the dictionary are accessible as properties of the ``_options``-member. Only keys that are
     in the ``default_options`` member of the class are accepted. Inheriting classes must override
     ``default_options`` to be a dictionary with the possible options for the adapter.
-    
+
     Each adapter has a ``lock`` member, which contains a :class:`NoLock` by default. To make
     device access thread-safe, any adapter should acquire this lock before interacting with
     the device (or interface). This means that before starting the server component of an Adapter,

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -24,7 +24,7 @@ an :mod:`Adapter <lewis.adapters>`).
 
 from datetime import datetime
 
-from lewis.core.adapters import AdapterCollection
+from lewis.core.adapters import AdapterCollection, MultiThreadedAdapterCollection
 from lewis.core.control_server import ControlServer, ExposedObject
 from lewis.core.devices import DeviceRegistry
 from lewis.core.logging import has_log
@@ -84,7 +84,7 @@ class Simulation(object):
         self._device_builder = device_builder
 
         self._device = device
-        self._adapters = AdapterCollection(adapter)
+        self._adapters = MultiThreadedAdapterCollection(adapter)
 
         self._speed = 1.0  # Multiplier for delta t
         self._cycle_delay = 0.1  # Target time between cycles
@@ -125,7 +125,7 @@ class Simulation(object):
             'interface': ExposedObject(
                 self._adapters,
                 exclude=('add_adapter', 'remove_adapter', 'handle', 'log'),
-                exclude_inherited=True
+                exclude_inherited=False
             )},
             control_server)
 

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -48,7 +48,7 @@ class Simulation(object):
     In the simplest case, the actual time-delta between two cycles
     is passed to the simulated device so that it can update its internal
     state according to the elapsed time. It is however possible to set
-    a simulation speed, which serv es as a multiplier for this time.
+    a simulation speed, which serves as a multiplier for this time.
     If the speed is set to 2 and 0.1 seconds pass between two cycles,
     the simulation is asked to simulate 0.2 seconds, and so on. Speed 0
     effectively stops all time dependent calculations in the

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -125,8 +125,8 @@ class Simulation(object):
             ),
             'interface': ExposedObject(
                 self._adapters,
-                exclude=('add_adapter', 'remove_adapter', 'handle', 'log'),
-                exclude_inherited=False
+                exclude=('device_lock', 'add_adapter', 'remove_adapter', 'handle', 'log'),
+                exclude_inherited=True
             )},
             control_server)
 

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -23,8 +23,9 @@ an :mod:`Adapter <lewis.adapters>`).
 """
 
 from datetime import datetime
+from time import sleep
 
-from lewis.core.adapters import MultiThreadedAdapterCollection, NoLock
+from lewis.core.adapters import AdapterCollection
 from lewis.core.control_server import ControlServer, ExposedObject
 from lewis.core.devices import DeviceRegistry
 from lewis.core.logging import has_log
@@ -84,7 +85,7 @@ class Simulation(object):
         self._device_builder = device_builder
 
         self._device = device
-        self._adapters = MultiThreadedAdapterCollection(adapter)
+        self._adapters = AdapterCollection(adapter)
 
         self._speed = 1.0  # Multiplier for delta t
         self._cycle_delay = 0.1  # Target time between cycles
@@ -212,12 +213,12 @@ class Simulation(object):
         """
         self.log.debug('Cycle, dt=%s', delta)
 
-        self._adapters.handle(self._cycle_delay)
+        sleep(self._cycle_delay)
 
         if self._running:
             delta_simulation = delta * self._speed
 
-            with self._adapters.lock:
+            with self._adapters._lock:
                 self._device.process(delta_simulation)
 
                 if self._control_server:

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -218,7 +218,7 @@ class Simulation(object):
         if self._running:
             delta_simulation = delta * self._speed
 
-            with self._adapters._lock:
+            with self._adapters.device_lock:
                 self._device.process(delta_simulation)
 
                 if self._control_server:

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -140,6 +140,8 @@ class TestAdapterCollection(unittest.TestCase):
         self.assertRaises(RuntimeError, collection.connect, 'baz')
         self.assertRaises(RuntimeError, collection.disconnect, 'baz')
 
+        collection.disconnect()  # Clean up so that the test does not hang
+
     def test_configuration(self):
         collection = AdapterCollection(
             DummyAdapter('protocol_a', options={'bar': 2, 'foo': 3}),

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -1,7 +1,7 @@
 import inspect
 import unittest
 
-from mock import patch, call, Mock, MagicMock
+from mock import Mock, MagicMock
 
 from lewis.core.adapters import Adapter, AdapterCollection
 from lewis.core.exceptions import LewisException
@@ -130,22 +130,6 @@ class TestAdapterCollection(unittest.TestCase):
 
         self.assertRaises(RuntimeError, collection.connect, 'baz')
         self.assertRaises(RuntimeError, collection.disconnect, 'baz')
-
-    @patch.object(DummyAdapter, 'handle')
-    @patch('lewis.core.adapters.sleep')
-    def test_handle_calls_all_adapters_or_sleeps(self, sleep_mock, adapter_mock):
-        collection = AdapterCollection(DummyAdapter('foo', running=False),
-                                       DummyAdapter('bar', running=False))
-        collection.handle(0.1)
-
-        sleep_mock.assert_has_calls([call(0.05), call(0.05)])
-        sleep_mock.reset_mock()
-
-        collection.connect('foo')
-
-        collection.handle(0.1)
-        sleep_mock.assert_has_calls([call(0.05)])
-        adapter_mock.assert_has_calls([call(0.05)])
 
     def test_configuration(self):
         collection = AdapterCollection(

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -3,7 +3,7 @@ import unittest
 
 from mock import Mock, MagicMock
 
-from lewis.core.adapters import Adapter, AdapterCollection
+from lewis.core.adapters import Adapter, AdapterCollection, NoLock
 from lewis.core.exceptions import LewisException
 from . import assertRaisesNothing
 
@@ -36,6 +36,15 @@ class DummyAdapter(Adapter):
     @property
     def is_running(self):
         return self._running
+
+
+class TestNoLock(unittest.TestCase):
+    def test_raises_when_used(self):
+        def failing_function():
+            with NoLock():
+                pass
+
+        self.assertRaises(RuntimeError, failing_function)
 
 
 class TestAdapter(unittest.TestCase):

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -100,14 +100,11 @@ class TestSimulation(unittest.TestCase):
         device_mock.assert_has_calls([call.process(0.5)])
 
     def test_process_cycle_calls_process_simulation(self):
-        adapter_mock = Mock()
         device_mock = Mock()
-        env = Simulation(device=device_mock, adapter=adapter_mock)
+        env = Simulation(device=device_mock, adapter=Mock())
         set_simulation_running(env)
 
         env._process_cycle(0.5)
-        adapter_mock.assert_has_calls(
-            [call.handle(env.cycle_delay)])
         device_mock.assert_has_calls(
             [call.process(0.5)]
         )
@@ -116,17 +113,14 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(env.runtime, 0.5)
 
     def test_process_simulation_cycle_applies_speed(self):
-        adapter_mock = Mock()
         device_mock = Mock()
 
-        env = Simulation(device=device_mock, adapter=adapter_mock)
+        env = Simulation(device=device_mock, adapter=Mock())
         set_simulation_running(env)
 
         env.speed = 2.0
         env._process_cycle(0.5)
 
-        adapter_mock.assert_has_calls(
-            [call.handle(env.cycle_delay)])
         device_mock.assert_has_calls(
             [call.process(1.0)])
 

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -31,6 +31,13 @@ def set_simulation_running(environment):
 
 
 class TestSimulation(unittest.TestCase):
+    def setUp(self):
+        # This makes sure that no actual sleeps happen during the tests.
+        # The recipe is from the mock documentation.
+        patcher = patch('lewis.core.simulation.sleep')
+        self.addCleanup(patcher.stop)
+        self.mock_sleep = patcher.start()
+
     @patch('lewis.core.simulation.seconds_since')
     def test_process_cycle_returns_elapsed_time(self, elapsed_seconds_mock):
         env = Simulation(device=Mock(), adapter=Mock())


### PR DESCRIPTION
This fixes #224.

This is a suggestion for how the threaded Adapters could work. As discussed on Slack, the old serial adapter processing has been replaced completely. `AdapterCollection` does not have a `handle`-Method any more, instead the `Simulation` simply sleeps for the appropriate time.

This still needs work on the Modbus adapter.