### PR TITLE
Change how framework_version is handled by default

### DIFF
--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -103,8 +103,9 @@ New features
 
    .. warning::
 
-      This feature has changed in the following release. It is no longer mandatory to specify
-      ``framework_version``, but still possible and encouraged.
+      This feature changes in the following release. It is no longer mandatory to specify
+      ``framework_version``, but still possible and encouraged, and ``--relaxed-versions``
+      is replaced with ``--ignore-versions``.
 
  - A new flag ``-V/--verify`` has been added to the ``lewis``-script. When activated, it sets
    the output level to ``debug`` and exits before actually starting the simulation. This can
@@ -201,4 +202,8 @@ Lewis `1.0.3`:
 
       $ lewis linkam_t95 -R
       $ lewis linkam_t95 --relaxed-versions
+      
+   :: warning:
 
+      In the next release, specifying ``framework_version`` becomes optional and 
+      ``--relaxed-versions`` is renamed to ``--ignore-versions``. 

--- a/docs/release_notes/release_1_0_3.rst
+++ b/docs/release_notes/release_1_0_3.rst
@@ -93,18 +93,23 @@ New features
    versions of Lewis, or hint them to update. By default, Lewis won't start if a device specifies
    another framework version, but this behavior can be overridden by using the new flag
    ``-R/--relaxed-versions``:
-   
+
    ::
-   
+
       $ lewis some_device -R
-      
+
    In this case the simulation will start, but a warning will still be logged so that this can be
    identified as a potential source of errors later on.
-   
+
+   .. warning::
+
+      This feature has changed in the following release. It is no longer mandatory to specify
+      ``framework_version``, but still possible and encouraged.
+
  - A new flag ``-V/--verify`` has been added to the ``lewis``-script. When activated, it sets
    the output level to ``debug`` and exits before actually starting the simulation. This can
    help diagnose problems with device modules or input parameters.
-   
+
 Bug fixes and other improvements
 --------------------------------
 
@@ -124,24 +129,24 @@ Bug fixes and other improvements
    notably a settable timeout for requests was added so that incomplete requests do not cause the
    client to hang anymore. In ``lewis-control`` script, a new ``-t/--timeout`` argument was added
    to make use of that new functionality.
-   
+
  - Only members defined as part of the device class are listed when using ``lewis-control device``.
-   ``lewis-control`` generally no longer lists inherited framework functions such as ``log``, 
-   ``add_processor``, etc. 
+   ``lewis-control`` generally no longer lists inherited framework functions such as ``log``,
+   ``add_processor``, etc.
 
 Upgrade Guide
 -------------
 
-The following changes have to be made to upgrade code working with Lewis `1.0.2` to work with 
+The following changes have to be made to upgrade code working with Lewis `1.0.2` to work with
 Lewis `1.0.3`:
 
- - Any scripts or code starting Lewis with the old style adapter parameters need to be updated to 
-   the new style adapter options. 
-   
+ - Any scripts or code starting Lewis with the old style adapter parameters need to be updated to
+   the new style adapter options.
+
    For EPICS adapters:
-   
+
    ::
-   
+
       Old style:
       $ lewis chopper
       $ lewis chopper -p epics
@@ -151,11 +156,11 @@ Lewis `1.0.3`:
       $ lewis chopper
       $ lewis chopper -p epics
       $ lewis chopper -p "epics: {prefix: 'SIM:'}"
-      
+
    For TCP Stream adapters:
-   
+
    ::
-   
+
        Old style:
        $ lewis linkam_t95
        $ lewis linkam_t95 -p stream
@@ -165,11 +170,11 @@ Lewis `1.0.3`:
        $ lewis linkam_t95
        $ lewis linkam_t95 -p stream
        $ lewis linkam_t95 -p "stream: {bind_address: 127.0.0.1, port: 9999, telnet_mode: True}"
-       
+
    For Modbus adapters:
-   
+
    ::
-   
+
       Old style:
       $ lewis -k lewis.examples modbus_device
       $ lewis -k lewis.examples modbus_device -p modbus
@@ -179,21 +184,21 @@ Lewis `1.0.3`:
       $ lewis -k lewis.examples modbus_device
       $ lewis -k lewis.examples modbus_device -p modbus
       $ lewis -k lewis.examples modbus_device -p "modbus: {bind_address: 127.0.0.1, port: 5020}"
-   
- - Devices must now specify a ``framework_version`` in the global namespace of their top-level 
+
+ - Devices must now specify a ``framework_version`` in the global namespace of their top-level
    ``__init__.py``, like this:
-   
+
    ::
-   
+
       framework_version = '1.0.3'
-   
-   This will need to be updated with every release. If this version is missing or does not match 
-   the current Lewis framework version, attempting to run the device simulation will fail with a 
-   message informing the user of the mismatch. This can be bypassed by starting Lewis with the 
+
+   This will need to be updated with every release. If this version is missing or does not match
+   the current Lewis framework version, attempting to run the device simulation will fail with a
+   message informing the user of the mismatch. This can be bypassed by starting Lewis with the
    following parameter:
-   
+
    ::
-   
+
       $ lewis linkam_t95 -R
       $ lewis linkam_t95 --relaxed-versions
-   
+

--- a/docs/release_notes/release_1_1_0.rst
+++ b/docs/release_notes/release_1_1_0.rst
@@ -82,6 +82,21 @@ Bug fixes and other improvements
    that slow network communication or expensive computations in the device do not influence
    one another anymore. Otherwise, communication still works exactly like in previous versions.
 
+ - The behavior of the ``framework_version``-variable for devices that was introduced in version
+   1.0.3 has been modified to make it easier to convert from older versions of Lewis.
+
+   With the default options of the ``lewis``-command, devices that do not specify the variable
+   will be loaded after logging a warning. An error message is only displayed when strict
+   version checking is enabled through the new ``-S/--strict-versions``-flag.
+
+   The option to ignore version mismatches has been renamed to ``-I/--ignore-versions``. When
+   that flag is specified, any device regardless of the contents of ``framework_version`` is
+   loaded, but a warning is still logged.
+
+   Specifying the ``framework_version`` variable is still encouraged as it can contribute to
+   more certainty on the user side as to whether a device can function with a certain function
+   of Lewis.
+
 Upgrade guide
 -------------
 

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -389,7 +389,7 @@ class SimulationFactory(object):
 
     .. sourcecode:: Python
 
-        factory = SimulationFactory('lewis.devices', relaxed_versions=True)
+        factory = SimulationFactory('lewis.devices')
 
     The actual creation happens via the :meth:`create`-method:
 
@@ -402,9 +402,9 @@ class SimulationFactory(object):
     .. warning:: This class is meant for internal use at the moment and may change frequently.
     """
 
-    def __init__(self, devices_package, relaxed_versions=False):
+    def __init__(self, devices_package, strict_versions=None):
         self._reg = DeviceRegistry(devices_package)
-        self._rv = relaxed_versions
+        self._rv = strict_versions
 
     @property
     def devices(self):

--- a/lewis/core/utils.py
+++ b/lewis/core/utils.py
@@ -372,7 +372,7 @@ def is_compatible_with_framework(version):
     .. _semantic_version: https://pypi.python.org/pypi/semantic_version/
     """
     if version is None:
-        return False
+        return None
 
     lewis_version = Version(__version__)
 

--- a/lewis/examples/dual_device/__init__.py
+++ b/lewis/examples/dual_device/__init__.py
@@ -75,4 +75,4 @@ class VerySimpleStreamInterface(StreamInterface):
     out_terminator = '\r\n'
 
 
-#framework_version = '1.0.4'
+framework_version = '1.0.3'

--- a/lewis/examples/dual_device/__init__.py
+++ b/lewis/examples/dual_device/__init__.py
@@ -75,4 +75,4 @@ class VerySimpleStreamInterface(StreamInterface):
     out_terminator = '\r\n'
 
 
-framework_version = '1.0.3'
+#framework_version = '1.0.4'

--- a/test/test_core_devices.py
+++ b/test/test_core_devices.py
@@ -251,11 +251,22 @@ class TestDeviceRegistry(TestWithPackageStructure):
             self.assertEquals(builder.name, 'some_file')
 
         with patch('lewis.core.devices.is_compatible_with_framework', return_value=False):
-            builder = registry.device_builder('some_file', relaxed_versions=True)
+            builder = registry.device_builder('some_file', strict_versions=False)
             self.assertEquals(builder.name, 'some_file')
 
+            self.assertRaises(LewisException, registry.device_builder, 'some_file')
             self.assertRaises(LewisException, registry.device_builder, 'some_file',
-                              relaxed_versions=False)
+                              strict_versions=True)
+
+        with patch('lewis.core.devices.is_compatible_with_framework', return_value=None):
+            builder = registry.device_builder('some_file', strict_versions=False)
+            self.assertEquals(builder.name, 'some_file')
+
+            builder = registry.device_builder('some_dir')
+            self.assertEquals(builder.name, 'some_dir')
+
+            self.assertRaises(LewisException, registry.device_builder, 'some_file',
+                              strict_versions=True)
 
         self.assertRaises(LewisException, registry.device_builder, 'invalid_device')
 


### PR DESCRIPTION
This does not have an issue assigned, but we've discussed it over the last two months. Basically the strict requirement that devices must have `framework_version` defined seemed to go a bit too far, so this is a slightly more forgiving approach.

When no options are supplied to `lewis`, devices without the `framework_version` variable are accepted, but if the variable is set it must match. To disable that check as well, there's a new `--ignore-versions` flag. To disallow loading devices without a `framework_version`, the `--strict-versions` flag can be specified.