### PR TITLE
Fix switch_setup bug

### DIFF
--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -236,6 +236,12 @@ class AdapterCollection(object):
         """
         return self._lock
 
+    def set_device(self, new_device):
+        """Bind the new device to all interfaces managed by the adapters in the collection."""
+        for adapter in self._adapters.values():
+            print(adapter.protocol, adapter.interface)
+            adapter.interface.device = new_device
+
     def add_adapter(self, adapter):
         """
         Adds the supplied adapter to the container but raises a ``RuntimeError`` if there's

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -239,7 +239,6 @@ class AdapterCollection(object):
     def set_device(self, new_device):
         """Bind the new device to all interfaces managed by the adapters in the collection."""
         for adapter in self._adapters.values():
-            print(adapter.protocol, adapter.interface)
             adapter.interface.device = new_device
 
     def add_adapter(self, adapter):

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -152,7 +152,7 @@ class Simulation(object):
         """
         try:
             self._device = self._device_builder.create_device(new_setup)
-            self._adapters.device = self._device
+            self._adapters.set_device(self._device)
             self.log.info('Switched setup to \'%s\'', new_setup)
         except Exception as e:
             self.log.error(

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -1,7 +1,7 @@
 import inspect
 import unittest
 
-from mock import Mock, MagicMock, PropertyMock, call, patch
+from mock import Mock, MagicMock
 
 from lewis.core.adapters import Adapter, AdapterCollection, NoLock
 from lewis.core.exceptions import LewisException

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -1,7 +1,7 @@
 import inspect
 import unittest
 
-from mock import Mock, MagicMock
+from mock import Mock, MagicMock, PropertyMock, call, patch
 
 from lewis.core.adapters import Adapter, AdapterCollection, NoLock
 from lewis.core.exceptions import LewisException
@@ -163,3 +163,12 @@ class TestAdapterCollection(unittest.TestCase):
                              {
                                  'protocol_b': {'bar': True, 'foo': False},
                              })
+
+    def test_set_device(self):
+        adapter = DummyAdapter(protocol='foo')
+        adapter.interface = MagicMock()
+
+        collection = AdapterCollection(adapter)
+        collection.set_device('test')
+
+        self.assertEqual(adapter.interface.device, 'test')


### PR DESCRIPTION
This fixes #241.

This re-enables proper switching of setups. The new device is exposed by all adapters.