### PR TITLE
Coerce versions so that 1.X matches 1.X.0

### DIFF
--- a/lewis/core/utils.py
+++ b/lewis/core/utils.py
@@ -374,6 +374,6 @@ def is_compatible_with_framework(version):
     if version is None:
         return None
 
-    lewis_version = Version(__version__)
+    lewis_version = Version.coerce(__version__)
 
-    return lewis_version == Version(''.join(version.split()))
+    return lewis_version == Version.coerce(version.strip())


### PR DESCRIPTION
Fixes #242.

Uses `Version.coerce` to avoid shorthand versions from throwing exceptions or failing to match longer versions.