### PR TITLE
Use pytest to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ python:
 
 install:
   - pip install -r requirements-dev.txt
-  - pip install coveralls
-  - pip install flake8
 
 script:
   - flake8 .
-  - nosetests -w test --with-coverage --cover-package=lewis.core,lewis.devices
+  - pytest --cov=lewis.core --cov=lewis.devices test
 
 after_success:
   - coveralls

--- a/lewis/core/devices.py
+++ b/lewis/core/devices.py
@@ -441,7 +441,7 @@ class DeviceRegistry(object):
             compatible = is_compatible_with_framework(builder.framework_version)
 
             if not compatible:
-                self.log.warn(
+                self.log.warning(
                     'Device \'%s\' is specified for a different framework version '
                     '(required: %s, current: %s). This means that the device might not work '
                     'as expected. Contact the device author about updating the device or use a '

--- a/lewis/core/simulation.py
+++ b/lewis/core/simulation.py
@@ -342,7 +342,7 @@ class Simulation(object):
         Stops the simulation entirely.
         """
 
-        self.log.warn('Stopping simulation')
+        self.log.warning('Stopping simulation')
 
         self._stop_commanded = True
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ sphinx_rtd_theme
 semantic_version
 PyYAML
 scanf>=1.4.1
-nose
+pytest
+pytest-cov
 coverage
 flake8

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ setup(
 
     extras_require={
         'epics': ['pcaspy'],
-        'dev': ['flake8', 'mock>=1.0.1', 'sphinx>=1.4.5', 'sphinx_rtd_theme'
-                'nose', 'coverage'],
+        'dev': ['flake8', 'mock>=1.0.1', 'sphinx>=1.4.5', 'sphinx_rtd_theme',
+                'pytest', 'pytest-cov', 'coverage'],
     },
 
     entry_points={

--- a/test/test_CanProcess.py
+++ b/test/test_CanProcess.py
@@ -83,7 +83,7 @@ class TestCanProcessComposite(unittest.TestCase):
         with patch.object(composite, '_append_processor') as appendProcessorMock:
             composite.add_processor(CanProcess())
 
-        self.assertEquals(appendProcessorMock.call_count, 1)
+        self.assertEqual(appendProcessorMock.call_count, 1)
 
     def test_addProcessor_if_argument_not_CanProcess(self):
         composite = CanProcessComposite()

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -28,7 +28,7 @@ from lewis.core.exceptions import LewisException
 from . import assertRaisesNothing
 
 
-class TestObject(object):
+class DummyObject(object):
     a = 10
     b = 20
 
@@ -37,13 +37,13 @@ class TestObject(object):
         self.setTest = Mock()
 
 
-class TestObjectChild(TestObject):
+class DummyObjectChild(DummyObject):
     c = 30
 
 
 class TestRPCObject(unittest.TestCase):
     def test_all_methods_exposed(self):
-        rpc_object = ExposedObject(TestObject())
+        rpc_object = ExposedObject(DummyObject())
 
         expected_methods = [':api', 'a:get', 'a:set', 'b:get', 'b:set', 'getTest', 'setTest']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -52,7 +52,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_select_methods_exposed(self):
-        rpc_object = ExposedObject(TestObject(), ('a', 'getTest'))
+        rpc_object = ExposedObject(DummyObject(), ('a', 'getTest'))
 
         expected_methods = [':api', 'a:get', 'a:set', 'getTest']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -61,7 +61,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_excluded_methods_not_exposed(self):
-        rpc_object = ExposedObject(TestObject(), exclude=('a', 'setTest'))
+        rpc_object = ExposedObject(DummyObject(), exclude=('a', 'setTest'))
 
         expected_methods = [':api', 'b:get', 'b:set', 'getTest']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -70,7 +70,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_selected_and_excluded_methods(self):
-        rpc_object = ExposedObject(TestObject(), members=('a', 'getTest'), exclude=('a'))
+        rpc_object = ExposedObject(DummyObject(), members=('a', 'getTest'), exclude=('a'))
 
         expected_methods = [':api', 'getTest']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -79,7 +79,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_inherited_not_exposed(self):
-        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'), exclude_inherited=True)
+        rpc_object = ExposedObject(DummyObjectChild(), members=('a', 'c'), exclude_inherited=True)
 
         expected_methods = [':api', 'c:get', 'c:set']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -88,7 +88,7 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_inherited_exposed(self):
-        rpc_object = ExposedObject(TestObjectChild(), members=('a', 'c'))
+        rpc_object = ExposedObject(DummyObjectChild(), members=('a', 'c'))
 
         expected_methods = [':api', 'a:get', 'a:set', 'c:get', 'c:set']
         self.assertEqual(len(rpc_object), len(expected_methods))
@@ -97,17 +97,17 @@ class TestRPCObject(unittest.TestCase):
             self.assertTrue(method in rpc_object)
 
     def test_invalid_method_raises(self):
-        self.assertRaises(AttributeError, ExposedObject, TestObject(), ('nonExisting',))
+        self.assertRaises(AttributeError, ExposedObject, DummyObject(), ('nonExisting',))
 
     def test_attribute_wrapper_gets_value(self):
-        obj = TestObject()
+        obj = DummyObject()
         obj.a = 233
 
         rpc_object = ExposedObject(obj)
         self.assertEqual(rpc_object['a:get'](), obj.a)
 
     def test_attribute_wrapper_sets_value(self):
-        obj = TestObject()
+        obj = DummyObject()
         obj.a = 233
 
         rpc_object = ExposedObject(obj)
@@ -117,14 +117,14 @@ class TestRPCObject(unittest.TestCase):
         self.assertEqual(obj.a, 20)
 
     def test_attribute_wrapper_argument_number(self):
-        rpc_object = ExposedObject(TestObject())
+        rpc_object = ExposedObject(DummyObject())
 
         self.assertRaises(TypeError, rpc_object['a:get'], 20)
         self.assertRaises(TypeError, rpc_object['a:set'])
         self.assertRaises(TypeError, rpc_object['a:set'], 40, 30)
 
     def test_method_wrapper_calls(self):
-        obj = TestObject()
+        obj = DummyObject()
         rpc_object = ExposedObject(obj)
 
         rpc_object['getTest'](45, 56)
@@ -132,7 +132,7 @@ class TestRPCObject(unittest.TestCase):
         obj.getTest.assert_called_with(45, 56)
 
     def test_get_api(self):
-        obj = TestObject()
+        obj = DummyObject()
         rpc_object = ExposedObject(obj, ['a'])
         api = rpc_object.get_api()
 
@@ -147,7 +147,7 @@ class TestRPCObject(unittest.TestCase):
         mock_lock.__enter__ = Mock()
         mock_lock.__exit__ = Mock()
 
-        obj = TestObject()
+        obj = DummyObject()
         exposed_object = ExposedObject(obj, ['a'], lock=mock_lock)
 
         self.assertEqual(exposed_object['a:get'](), obj.a)
@@ -175,7 +175,7 @@ class TestExposedObjectCollection(unittest.TestCase):
 
     def test_add_plain_object(self):
         exposed_objects = ExposedObjectCollection({})
-        obj = TestObject()
+        obj = DummyObject()
 
         assertRaisesNothing(self, exposed_objects.add_object, obj, 'testObject')
 
@@ -188,7 +188,7 @@ class TestExposedObjectCollection(unittest.TestCase):
 
     def test_add_exposed_object(self):
         exposed_objects = ExposedObjectCollection({})
-        obj = TestObject()
+        obj = DummyObject()
 
         assertRaisesNothing(self, exposed_objects.add_object,
                             ExposedObject(obj, ('setTest', 'getTest')), 'testObject')
@@ -196,7 +196,7 @@ class TestExposedObjectCollection(unittest.TestCase):
         obj.getTest.assert_called_once_with(41, 11)
 
     def test_nested_collections(self):
-        obj = TestObject()
+        obj = DummyObject()
         exposed_objects = ExposedObjectCollection(
             {'container': ExposedObjectCollection({'test': obj})})
 
@@ -205,20 +205,20 @@ class TestExposedObjectCollection(unittest.TestCase):
 
     def test_duplicate_name_raises(self):
         exposed_objects = ExposedObjectCollection({})
-        exposed_objects.add_object(TestObject(), 'testObject')
+        exposed_objects.add_object(DummyObject(), 'testObject')
 
-        self.assertRaises(RuntimeError, exposed_objects.add_object, TestObject(), 'testObject')
+        self.assertRaises(RuntimeError, exposed_objects.add_object, DummyObject(), 'testObject')
 
     def test_remove_object(self):
         exposed_objects = ExposedObjectCollection({})
         own_functions_count = len(exposed_objects)
 
-        obj = TestObject()
+        obj = DummyObject()
         exposed_objects.add_object(obj, 'testObject')
 
         self.assertListEqual(exposed_objects.get_objects(), ['testObject'])
         assertRaisesNothing(self, exposed_objects.remove_object, 'testObject')
-        self.assertEquals(len(exposed_objects), own_functions_count)
+        self.assertEqual(len(exposed_objects), own_functions_count)
 
         self.assertRaises(RuntimeError, exposed_objects.remove_object, 'does_not_exist')
 

--- a/test/test_core_adapters.py
+++ b/test/test_core_adapters.py
@@ -91,7 +91,7 @@ class TestAdapter(unittest.TestCase):
 class TestAdapterCollection(unittest.TestCase):
     def test_add_adapter(self):
         collection = AdapterCollection()
-        self.assertEquals(len(collection.protocols), 0)
+        self.assertEqual(len(collection.protocols), 0)
 
         assertRaisesNothing(self, collection.add_adapter, DummyAdapter('foo'))
 

--- a/test/test_core_devices.py
+++ b/test/test_core_devices.py
@@ -248,11 +248,11 @@ class TestDeviceRegistry(TestWithPackageStructure):
 
         with patch('lewis.core.devices.is_compatible_with_framework', return_value=True):
             builder = registry.device_builder('some_file')
-            self.assertEquals(builder.name, 'some_file')
+            self.assertEqual(builder.name, 'some_file')
 
         with patch('lewis.core.devices.is_compatible_with_framework', return_value=False):
             builder = registry.device_builder('some_file', strict_versions=False)
-            self.assertEquals(builder.name, 'some_file')
+            self.assertEqual(builder.name, 'some_file')
 
             self.assertRaises(LewisException, registry.device_builder, 'some_file')
             self.assertRaises(LewisException, registry.device_builder, 'some_file',
@@ -260,10 +260,10 @@ class TestDeviceRegistry(TestWithPackageStructure):
 
         with patch('lewis.core.devices.is_compatible_with_framework', return_value=None):
             builder = registry.device_builder('some_file', strict_versions=False)
-            self.assertEquals(builder.name, 'some_file')
+            self.assertEqual(builder.name, 'some_file')
 
             builder = registry.device_builder('some_dir')
-            self.assertEquals(builder.name, 'some_dir')
+            self.assertEqual(builder.name, 'some_dir')
 
             self.assertRaises(LewisException, registry.device_builder, 'some_file',
                               strict_versions=True)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -30,7 +30,7 @@ class TestHasLog(unittest.TestCase):
 
         a = Foo()
 
-        self.assertEquals(a.log.name, '{}.Foo'.format(root_logger_name))
+        self.assertEqual(a.log.name, '{}.Foo'.format(root_logger_name))
 
     def test_setting_context_changes_name(self):
         @has_log
@@ -38,13 +38,13 @@ class TestHasLog(unittest.TestCase):
             pass
 
         a = Foo()
-        self.assertEquals(a.log.name, '{}.Foo'.format(root_logger_name))
+        self.assertEqual(a.log.name, '{}.Foo'.format(root_logger_name))
 
         a._set_logging_context('some_context')
-        self.assertEquals(a.log.name, '{}.some_context.Foo'.format(root_logger_name))
+        self.assertEqual(a.log.name, '{}.some_context.Foo'.format(root_logger_name))
 
         a._set_logging_context(None)
-        self.assertEquals(a.log.name, '{}.Foo'.format(root_logger_name))
+        self.assertEqual(a.log.name, '{}.Foo'.format(root_logger_name))
 
     def test_decorate_function(self):
         @has_log
@@ -52,4 +52,4 @@ class TestHasLog(unittest.TestCase):
             return bar
 
         self.assertTrue(hasattr(foo, 'log'))
-        self.assertEquals(foo.log.name, '{}.foo'.format(root_logger_name))
+        self.assertEqual(foo.log.name, '{}.foo'.format(root_logger_name))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -277,7 +277,7 @@ class TestCheckLimits(unittest.TestCase):
         assertRaisesNothing(self, f.set_bar, 16)
 
         # Updates must have been ignored.
-        self.assertEquals(f.bar, 15)
+        self.assertEqual(f.bar, 15)
 
 
 class TestCompatibleWithFramework(unittest.TestCase):


### PR DESCRIPTION
This fixes #249.

The command line to run all tests manually from the top level directory is now:

```
$ pytest test
```

To get coverage information equivalent to what we have in Travis:

```
$ pytest --cov=lewis.core --cov=lewis.devices test
```

`pytest` warned about some deprecated methods, such as `log.warn` instead of `log.warning` and `self.assertEquals` that we were oddly using in some places, I've fixed those as well.