### PR TITLE
Stream timeout mode

### DIFF
--- a/docs/release_notes/release_1_1_2.rst
+++ b/docs/release_notes/release_1_1_2.rst
@@ -8,6 +8,20 @@ is operating closer to the packages that are released in the end. This only affe
 who work on the Lewis code base. In addition, :mod:`lewis.adapters.epics` was improved a bit
 with better error messages and more reasonable PV update frequencies.
 
+New Features
+------------
+ - :class:`StreamInterface` has been improved to support a ``readtimeout`` attribute which is analogous
+   to the ReadTimeout system variable in Protocol files. The value of ``readtimeout`` determines how
+   many milliseconds to wait for more input, once we have started receiving data for a command. Under
+   normal circumstances, this timeout being triggered is an error and causes the incoming buffer to be
+   flushed and a ``handle_error`` call in the device interface. However, if the ``in_terminator``
+   attribute is empty, this timeout is treated as the command terminator instead.
+
+   ``readtimeout`` defaults to 100 (ms).
+   ``readtimeout = 0`` disables this feature entirely.
+
+   The effective resolution is currently limited 10 ms increments due to the fixed adapter cycle rate.
+
 Bugfixes and other improvements
 -------------------------------
  - Error messages in the binding step of :class:`PV` have been improved. It is now easier to find

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -675,6 +675,8 @@ class StreamInterface(InterfaceBase):
     in_terminator = '\r'
     out_terminator = '\r'
 
+    readtimeout = 100
+
     commands = None
 
     def __init__(self):

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -48,8 +48,8 @@ class StreamHandler(asynchat.async_chat):
         self.log.info('Client connected from %s:%s', *sock.getpeername())
 
     def process(self, msec):
-        if len(self._buffer) > 0:
-            self._readtimer += msec
+        if not self._buffer:
+            return
 
         if self._readtimer >= self._readtimeout and self._readtimeout != 0:
             if not self.get_terminator():
@@ -62,6 +62,9 @@ class StreamHandler(asynchat.async_chat):
                     error = RuntimeError("ReadTimeout while waiting for command terminator.")
                     reply = self._handle_error(request, error)
                 self._send_reply(reply)
+
+        if self._buffer:
+            self._readtimer += msec
 
     def collect_incoming_data(self, data):
         self._buffer.append(data)

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -649,12 +649,18 @@ class StreamInterface(InterfaceBase):
 
     Many hardware devices use a protocol that is based on exchanging text with a client via
     a TCP stream. Sometimes RS232-based devices are also exposed this way via an adapter-box.
-    This adapter makes it easy to mimic such a protocol, in a subclass only three members must
-    be overridden:
+    This adapter makes it easy to mimic such a protocol.
 
+    This class has the following attributes which may be overridden by subclasses:
+
+     - protocol: What this interface is called for purposes of the -p commandline option.
+       Defaults to "stream".
      - in_terminator, out_terminator: These define how lines are terminated when transferred
        to and from the device respectively. They are stripped/added automatically.
-       The default is ``\\r``.
+       Inverse of protocol file InTerminator and OutTerminator. The default is ``\\r``.
+     - readtimeout: How many msec to wait for additional data between packets, once transmission
+       of an incoming command has begun. Inverse of ReadTimeout in protocol files.
+       Defaults to 100 (ms).
      - commands: A list of :class:`~CommandBase`-objects that define mappings between protocol
        and device/interface methods/attributes.
 

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -86,8 +86,8 @@ class StreamHandler(asynchat.async_chat):
 
         with self._stream_server.device_lock:
             try:
-                cmd = next((cmd for cmd in self._target.bound_commands if cmd.can_process(request)),
-                           None)
+                cmd = next((cmd for cmd in self._target.bound_commands
+                            if cmd.can_process(request)), None)
 
                 if cmd is None:
                     raise RuntimeError('None of the device\'s commands matched.')

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -677,7 +677,7 @@ class StreamInterface(InterfaceBase):
        Inverse of protocol file InTerminator and OutTerminator. The default is ``\\r``.
      - readtimeout: How many msec to wait for additional data between packets, once transmission
        of an incoming command has begun. Inverse of ReadTimeout in protocol files.
-       Defaults to 100 (ms).
+       Defaults to 100 (ms). Set to 0 to disable timeout completely.
      - commands: A list of :class:`~CommandBase`-objects that define mappings between protocol
        and device/interface methods/attributes.
 

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -51,7 +51,7 @@ class StreamHandler(asynchat.async_chat):
         if len(self._buffer) > 0:
             self._readtimer += msec
 
-        if self._readtimer >= self._readtimeout:
+        if self._readtimer >= self._readtimeout and self._readtimeout != 0:
             if not self.get_terminator():
                 # If no terminator is set, this timeout is the terminator
                 self.found_terminator()

--- a/src/lewis/core/adapters.py
+++ b/src/lewis/core/adapters.py
@@ -287,7 +287,7 @@ class AdapterCollection(object):
             self.log.info('Connecting device interface for protocol \'%s\'', adapter.protocol)
 
             adapter_thread = threading.Thread(target=self._adapter_loop,
-                                              args=(adapter, 0.1))
+                                              args=(adapter, 0.01))
             adapter_thread.daemon = True
 
             self._threads[adapter.protocol] = adapter_thread

--- a/src/lewis/examples/timeout_device/__init__.py
+++ b/src/lewis/examples/timeout_device/__init__.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# *********************************************************************
+# lewis - a library for creating hardware device simulators
+# Copyright (C) 2016-2017 European Spallation Source ERIC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# *********************************************************************
+
+from lewis.devices import Device
+
+from lewis.adapters.stream import StreamInterface, Var, Cmd, scanf
+
+
+class TimeTerminatedDevice(Device):
+    param = 10
+
+    def say_world(self):
+        return "world!"
+
+    def say_bar(self):
+        return "bar!"
+
+
+class TimeTerminatedInterface(StreamInterface):
+    """
+    A simple device where commands are terminated by a timeout.
+
+    This demonstrates how to implement devices that do not have standard
+    terminators and where a command is considered terminated after a certain
+    time delay of not receiving more data.
+
+    To interact with this device, you must switch telnet into char mode, or use
+    netcat with special tty settings:
+
+        $ telnet host port
+        ^]
+        telnet> mode char
+        [type command and wait]
+
+        $ stty -icanon && nc host port
+        hello world!
+        foobar!
+
+    The following commands are available:
+
+     - ``hello ``: Reply with "world!"
+     - ``foo``: Replay with "bar!"
+     - ``P``: Returns the device parameter
+     - ``P=something``: Set parameter to specified value
+
+    """
+    commands = {
+        # Space as \x20 represents a custom 'terminator' for this command only
+        # However, waiting for the timeout still applies
+        Cmd('say_world', pattern=scanf('hello\x20')),
+        Cmd('say_bar', pattern=scanf('foo')),
+        Var('param', read_pattern=scanf('P'), write_pattern=scanf('P=%d')),
+    }
+
+    in_terminator = ''
+    out_terminator = '\r\n'
+
+    # Unusually long, for easier manual entry
+    readtimeout = 2500
+
+    def handle_error(self, request, error):
+        return 'An error occurred: ' + repr(error)

--- a/src/lewis/examples/timeout_device/__init__.py
+++ b/src/lewis/examples/timeout_device/__init__.py
@@ -68,6 +68,8 @@ class TimeTerminatedInterface(StreamInterface):
         Var('param', read_pattern=scanf('P'), write_pattern=scanf('P=%d')),
     }
 
+    # An empty in_terminator triggers "timeout mode"
+    # Otherwise, a ReadTimeout is considered an error.
     in_terminator = ''
     out_terminator = '\r\n'
 


### PR DESCRIPTION
Fixes #261.

Adds a `readtimeout` attribute to `StreamInterface`. A ReadTimeout is triggered when the adapter has begun receiving data (IE, a partial command), but has not yet received an InTerminator, and no further data has arrived for the number of milliseconds specified by the `readtimeout` attribute.

This behaviour is based on the description of ReadTimeout in the [Protocol File documentation](http://epics.web.psi.ch/software/streamdevice/doc/protocol.html#var), which seems to indicate that a timeout can be used to separate commands instead of a terminator.

> ReadTimeout = 100;
>     Integer. Affects `in` commands.
>     The device may send input in pieces (e.g. bytes). When it stops sending, how many milliseconds to wait for more input bytes before giving up? **If InTerminator = "", a read timeout is not an error but a valid input termination.**

This ReadTimeout is the inverse of what is implemented here, since this is written from the IOC's perspective, but it seems reasonable that it should work the same way in both directions.

## Testing

Run the supplied sample device:
```
$ lewis -k lewis.examples timeout_device
```

To interact with this device, you must switch telnet into char mode, or use netcat with special tty settings:
```
$ telnet host port
^]
telnet> mode char
[type command and wait]

$ stty -icanon && nc host port
hello world!
foobar!
```

The following commands are available:
 - `hello ` (with space): Reply with "world!"
 - `foo`: Reply with "bar!"
 - `P`: Returns the device parameter
 - `P=%d`: Set parameter to specified value

ReadTimeout is set to 2.5 seconds here.