### PR TITLE
Move control server to separate thread

### DIFF
--- a/docs/release_notes/release_1_2_0.rst
+++ b/docs/release_notes/release_1_2_0.rst
@@ -6,8 +6,8 @@ Release 1.2
 After releasing 1.1.0 and 1.1.1, we decided to move to a more reproducible testing workflow that
 is operating closer to the packages that are released in the end. This only affects developers
 who work on the Lewis code base. In addition, :mod:`lewis.adapters.epics` was improved a bit
-with better error messages and more reasonable PV update frequencies, and the ``lewis-control``
-was made more responsive.
+with better error messages and more reasonable PV update frequencies. The ``lewis-control``
+server now runs in its own thread, which has made it more responsive.
 
 New Features
 ------------
@@ -23,13 +23,15 @@ New Features
 
    The effective resolution is currently limited 10 ms increments due to the fixed adapter cycle rate.
 
+ - The :class:`~lewis.core.control_server.ControlServer` is now running in its own thread, separate
+   from the simulation. As a result, ``lewis-control`` and the Python Control API are now much more
+   responsive. This is because requests are processed asynchronously and, therefore, multiple
+   requests can be processed per simulation cycle.
+
+   .. note:: This may have an impact on scripts that use the CLI or Python Control API.
+
 Bugfixes and other improvements
 -------------------------------
- - The :class:`~lewis.core.control_server.ControlServer` is now running in its own separate thread.
-   This has two consequences, ``lewis-control`` is now much more responsive and requests
-   are processed instantaneously. Furthermore, multiple requests can be processed per
-   simulation cycle, which may have an impact on scripts that were relying on this behavior.
-
  - Error messages in the binding step of :class:`PV` have been improved. It is now easier to find
    the source of common problems (missing properties, spelling errors).
 

--- a/docs/release_notes/release_1_2_0.rst
+++ b/docs/release_notes/release_1_2_0.rst
@@ -6,7 +6,8 @@ Release 1.2
 After releasing 1.1.0 and 1.1.1, we decided to move to a more reproducible testing workflow that
 is operating closer to the packages that are released in the end. This only affects developers
 who work on the Lewis code base. In addition, :mod:`lewis.adapters.epics` was improved a bit
-with better error messages and more reasonable PV update frequencies.
+with better error messages and more reasonable PV update frequencies, and the ``lewis-control``
+was made more responsive.
 
 New Features
 ------------
@@ -24,6 +25,11 @@ New Features
 
 Bugfixes and other improvements
 -------------------------------
+ - The :class:`~lewis.core.control_server.ControlServer` is now running in its own separate thread.
+   This has two consequences, ``lewis-control`` is now much more responsive and requests
+   are processed instantaneously. Furthermore, multiple requests can be processed per
+   simulation cycle, which may have an impact on scripts that were relying on this behavior.
+
  - Error messages in the binding step of :class:`PV` have been improved. It is now easier to find
    the source of common problems (missing properties, spelling errors).
 

--- a/src/lewis/core/simulation.py
+++ b/src/lewis/core/simulation.py
@@ -203,7 +203,7 @@ class Simulation(object):
 
     def _stop_control_server(self):
         if self._control_server_thread is not None:
-            self._control_server_thread.join()
+            self._control_server_thread.join(timeout=1.0)
             self._control_server_thread = None
 
     def _process_cycle(self, delta):
@@ -242,9 +242,6 @@ class Simulation(object):
 
             with self._adapters.device_lock:
                 self._device.process(delta_simulation)
-
-            if self._control_server:
-                self._control_server.process()
 
             self._cycles += 1
             self._runtime += delta_simulation

--- a/src/lewis/scripts/run.py
+++ b/src/lewis/scripts/run.py
@@ -246,6 +246,8 @@ def run_simulation(argument_list=None):  # noqa: C901
             except KeyboardInterrupt:
                 print('\nInterrupt received; shutting down. Goodbye, cruel world!')
                 simulation.log.critical('Simulation aborted by user interaction')
+            finally:
+                simulation.stop()
 
     except LewisException as e:
         print('\n'.join(('An error occurred:', str(e))))

--- a/test/test_control_server.py
+++ b/test/test_control_server.py
@@ -230,6 +230,7 @@ class TestControlServer(unittest.TestCase):
         cs.start_server()
 
         mock_context.assert_has_calls([call(), call().socket(zmq.REP),
+                                       call().socket().setsockopt(zmq.RCVTIMEO, 100),
                                        call().socket().bind('tcp://127.0.0.1:10001')])
 
     @patch('zmq.Context')
@@ -239,6 +240,7 @@ class TestControlServer(unittest.TestCase):
         server.start_server()
 
         mock_context.assert_has_calls([call(), call().socket(zmq.REP),
+                                       call().socket().setsockopt(zmq.RCVTIMEO, 100),
                                        call().socket().bind('tcp://127.0.0.1:10000')])
 
     def test_process_raises_if_not_started(self):

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -134,17 +134,6 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(env.cycles, 1)
         self.assertEqual(env.runtime, 1.0)
 
-    def test_process_calls_control_server(self):
-        env = Simulation(device=Mock())
-
-        control_mock = Mock()
-        env._control_server = control_mock
-
-        set_simulation_running(env)
-        env._process_cycle(0.5)
-
-        control_mock.assert_has_calls([call.process()])
-
     def test_None_control_server_is_None(self):
         env = Simulation(device=Mock(), control_server=None)
 


### PR DESCRIPTION
This change moves the control server into a separate thread. This makes `lewis-control` a lot more responsive.

To test, start a device with control server enabled:

```
$ lewis -r localhost:10000 -k lewis.examples example_motor
```

In a different terminal, run:
```
$ lewis-control simulation
```
The output should appear more or less instantaneously. I had to modify the code for catching the keyboard interrupt slightly, there's a `finally` clause now that stops the simulation, doing a proper shutdown of any adapters and the control server. Otherwise the control server can not exit (`_stop_commanded` never gets set).