### PR TITLE
Removed Wedel's email as it is no longer valid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     url='https://github.com/DMSC-Instrument-Data/lewis',
     author='Michael Hart, Michael Wedel, Owen Arnold',
     author_email='Michael Hart <michael.hart@stfc.ac.uk>, '
-                 'Michael Wedel <michael.wedel@esss.se>, '
                  'Owen Arnold <owen.arnold@stfc.ac.uk>',
     license='GPL v3',
     classifiers=[


### PR DESCRIPTION
This is to address that Michael Wedel's `esss.se` email is no longer active.

For a while I considered changing the email to the GitHub noreply one, but the `author_email` field is for purposes of contact information, and that wouldn't be very useful for contacting. So I opted to just remove the email altogether.

Maybe you want to change it to a different email instead?