### PR TITLE
Add support for sending unsolicited messages from a device

### DIFF
--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -109,7 +109,7 @@ class StreamHandler(asynchat.async_chat):
 
         self._send_reply(reply)
 
-    def unsolicitedReply(self, reply):
+    def unsolicited_reply(self, reply):
         self.log.debug('Sending unsolicited reply %s', reply)
         self.push(b(reply + self._target.out_terminator))
 

--- a/src/lewis/adapters/stream.py
+++ b/src/lewis/adapters/stream.py
@@ -43,6 +43,7 @@ class StreamHandler(asynchat.async_chat):
         self._buffer = []
 
         self._stream_server = stream_server
+        self._target.handler = self
 
         self._set_logging_context(target)
         self.log.info('Client connected from %s:%s', *sock.getpeername())
@@ -107,6 +108,10 @@ class StreamHandler(asynchat.async_chat):
                 reply = self._handle_error(request, error)
 
         self._send_reply(reply)
+
+    def unsolicitedReply(self, reply):
+        self.log.debug('Sending unsolicited reply %s', reply)
+        self.push(b(reply + self._target.out_terminator))
 
     def handle_close(self):
         self.log.info('Closing connection to client %s:%s', *self.socket.getpeername())


### PR DESCRIPTION
This is used, for example, in the simulated gamry device. It sends a "charge complete"
unsolicited message some seconds after being sent a command to "start charging".

The PR adds a unsolicited_reply() method so code like the following in the device
StreamInterface can accomplish this:

    # function to send unsolicited message when charging complete
    def charged(self):
        self.handler.unsolicited_reply("STOPPED")

    # Device commanded to start charging
    def start_charging(self):
        t = Timer(self.charging_time, self.charged)
        t.start()
        return "STARTED"
