### PR TITLE
Remove trailing whitespace when comparing stuff in the approval tests.

### DIFF
--- a/docs/developer_guide/developing_lewis.rst
+++ b/docs/developer_guide/developing_lewis.rst
@@ -47,7 +47,7 @@ values can be compared against the expected status (the "golden master"). The te
 
 ::
 
-    (lewis-dev)$ pytest system_tests\lewis_tests.py
+    (lewis-dev)$ pytest system_tests/lewis_tests.py
 
 It is good practice to run these tests regularly during development and, also, look for opportunities to add
 more tests. The tests will also be run via the CI system.

--- a/system_tests/lewis_tests.py
+++ b/system_tests/lewis_tests.py
@@ -39,7 +39,8 @@ def run_control_command(mode, command, value):
 
 
 def santise_whitespace(input_str):
-    return "\n".join(input_str.split())
+    result = "\n".join(input_str.split())
+    return result.rstrip()
 
 
 def query_device_status():


### PR DESCRIPTION
Should make the tests more robust