### PR TITLE
Fix GitHub links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ The Pull Request description should detail the purpose of the Pull Request, and
 where appropriate should include some instructions on how to test the changes.
 
 Please ensure your Pull Request passes all integration tests and is able to be
-merged with master automatically.
+merged with the main branch automatically.
 
 
 Submitting Devices

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ by Lewis. The ``Device`` and ``Interface`` are instantiated as part of a
 ``Simulation`` that provides a cycle "heart beat" and manages other
 environmental aspects and services.
 
-.. image:: https://github.com/ess-dmsc/lewis/raw/master/docs/resources/diagrams/SimulationCycles.png
+.. image:: https://github.com/ess-dmsc/lewis/raw/main/docs/resources/diagrams/SimulationCycles.png
 
 What Can You Do With Lewis?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -86,4 +86,4 @@ What Can You Do With Lewis?
 -  Control server can be accessed via command-line utility, Python bindings, or
    JSON RPC.
 
-.. |Lewis| image:: https://github.com/ess-dmsc/lewis/raw/master/docs/resources/logo/lewis-logo.png
+.. |Lewis| image:: https://github.com/ess-dmsc/lewis/raw/main/docs/resources/logo/lewis-logo.png

--- a/docs/developer_guide/release_checklist.rst
+++ b/docs/developer_guide/release_checklist.rst
@@ -52,7 +52,7 @@ GitHub Release
 Merge Changes
 -------------
 
- - Merge any changes made in this section into master
+ - Merge any changes made in this section into the main branch
  - Ensure this pull request is also tagged for the current version
 
 

--- a/docs/developer_guide/writing_devices.rst
+++ b/docs/developer_guide/writing_devices.rst
@@ -427,7 +427,7 @@ Once a device is developed far enough, it's time to submit a pull
 request. As an external contributor, this happens via a fork on github.
 Members of the development team will review the code and may make
 suggestions for changes. Once the code is acceptable, it will be merged
-into Lewis' master branch and become a part of the distribution.
+into Lewis' main branch and become a part of the distribution.
 
 If a second interface is added to a device, either using a different
 interface type or the same but with different commands, the interface

--- a/docs/quickstart_guide/index.rst
+++ b/docs/quickstart_guide/index.rst
@@ -120,7 +120,7 @@ Note that the commands are case sensitive. Try entering a few commands in the Te
     P?
     9.106584
 
-See `the source code <https://github.com/ess-dmsc/lewis/blob/master/lewis/examples/example_motor/__init__.py>`_ of the example motor if you want to see what makes it tick.
+See `the source code <https://github.com/ess-dmsc/lewis/blob/main/lewis/examples/example_motor/__init__.py>`_ of the example motor if you want to see what makes it tick.
 
 
 Connect to Motor via Control Client


### PR DESCRIPTION
I assume this is due to a branch move from master to main.

Also maybe related: it appears the documentation links all return 404, maybe this is because readthedocs is trying to build the master branch, which doesn't exist anymore?

Thanks a lot!