### PR TITLE
Run unit tests on python 3.14; run wheel builds on python 3.13

### DIFF
--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -5,12 +5,12 @@ jobs:
     uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@main
     with:
       compare-branch: origin/main
-      python-ver: '3.11'
+      python-ver: '3.13'
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['3.10','3.11', '3.12', '3.13']
+        version: ['3.10','3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.13"
     - name: Install pypa/build
       run: >-
         python3 -m


### PR DESCRIPTION
And run reusable-workflows on py 3.13