### PR TITLE
run tests on windows

### DIFF
--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -13,8 +13,8 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.version }}
       - name: install requirements

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -7,10 +7,11 @@ jobs:
       compare-branch: origin/main
       python-ver: '3.13'
   tests:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         version: ['3.10','3.11', '3.12', '3.13', '3.14']
+        os: ["ubuntu-latest", "windows-latest"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.version }}
-          activate-environment: "true"
       - name: install requirements
         run: uv sync --extra dev
       - name: run unit tests

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.version }}
+          activate-environment: "true"
       - name: install requirements
         run: uv sync --extra dev
       - name: run unit tests

--- a/system_tests/lewis_tests.py
+++ b/system_tests/lewis_tests.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -18,8 +19,7 @@ LEWIS_CONTROL_PATH = Path(TOP_DIR) / "scripts/lewis-control.py"
 @contextlib.contextmanager
 def julabo_simulation():
     command = [
-        "uv",
-        "run",
+        sys.executable,
         str(LEWIS_PATH),
         "julabo",
         "-p",
@@ -34,7 +34,9 @@ def julabo_simulation():
 
 
 def run_control_command(mode, command, value):
-    subprocess.check_output(["uv", "run", str(LEWIS_CONTROL_PATH), mode, command, value]).decode()
+    subprocess.check_output(
+        [sys.executable, str(LEWIS_CONTROL_PATH), mode, command, value]
+    ).decode()
 
 
 def santise_whitespace(input_str):
@@ -43,7 +45,7 @@ def santise_whitespace(input_str):
 
 def query_device_status():
     return santise_whitespace(
-        subprocess.check_output(["uv", "run", str(LEWIS_CONTROL_PATH), "device"]).decode()
+        subprocess.check_output([sys.executable, str(LEWIS_CONTROL_PATH), "device"]).decode()
     )
 
 
@@ -58,7 +60,7 @@ class TestLewis:
         Then: returns a list of possible simulations
         """
         result = santise_whitespace(
-            subprocess.check_output(["uv", "run", str(LEWIS_PATH)]).decode()
+            subprocess.check_output([sys.executable, str(LEWIS_PATH)]).decode()
         )
 
         verify(result, self.reporter)

--- a/system_tests/lewis_tests.py
+++ b/system_tests/lewis_tests.py
@@ -57,7 +57,9 @@ class TestLewis:
         When: running Lewis without parameters
         Then: returns a list of possible simulations
         """
-        result = santise_whitespace(subprocess.check_output(["uv", "run", str(LEWIS_PATH)]).decode())
+        result = santise_whitespace(
+            subprocess.check_output(["uv", "run", str(LEWIS_PATH)]).decode()
+        )
 
         verify(result, self.reporter)
 

--- a/system_tests/lewis_tests.py
+++ b/system_tests/lewis_tests.py
@@ -34,7 +34,7 @@ def julabo_simulation():
 
 
 def run_control_command(mode, command, value):
-    subprocess.check_output(["uv", "run", str(LEWIS_CONTROL_PATH), mode, command, value], env=os.environ).decode()
+    subprocess.check_output(["uv", "run", str(LEWIS_CONTROL_PATH), mode, command, value]).decode()
 
 
 def santise_whitespace(input_str):
@@ -43,7 +43,7 @@ def santise_whitespace(input_str):
 
 def query_device_status():
     return santise_whitespace(
-        subprocess.check_output(["uv", "run", str(LEWIS_CONTROL_PATH), "device"], env=os.environ).decode()
+        subprocess.check_output(["uv", "run", str(LEWIS_CONTROL_PATH), "device"]).decode()
     )
 
 


### PR DESCRIPTION
i accidentally pushed [this](https://github.com/ISISComputingGroup/lewis/commit/544fff75805b6f1cbfe67c82ce7ea9387c9f07f8) to master which is what _actually_ fixes the system tests on windows - it was picking up the system installed python exe on windows, `uv` actually solves this for us by using the local venv and not having to worry about running `source .venv/bin/activate || .venv\scripts\activate`